### PR TITLE
Support additional metadata

### DIFF
--- a/eureka/list.go
+++ b/eureka/list.go
@@ -9,14 +9,17 @@ import (
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/format"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient"
 	"net/http"
+	"strings"
 )
 
 type Instance struct {
 	App      string
 	Status   string
 	Metadata struct {
-		Zone string
-	}
+			 CfAppGuid       string
+			 CfInstanceIndex string
+			 Zone            string
+		 }
 }
 
 type ApplicationInstance struct {
@@ -25,9 +28,14 @@ type ApplicationInstance struct {
 
 type ListResp struct {
 	Applications struct {
-		Application []ApplicationInstance
-	}
+			     Application []ApplicationInstance
+		     }
 }
+
+const (
+	UnknownCfAppName = "?????"
+	UnknownCfInstanceIndex = "?"
+)
 
 func List(cliConnection plugin.CliConnection, client httpclient.Client, srInstanceName string) (string, error) {
 	serviceModel, err := cliConnection.GetService(srInstanceName)
@@ -46,7 +54,7 @@ func List(cliConnection plugin.CliConnection, client httpclient.Client, srInstan
 		return "", fmt.Errorf("Access token not available: %s", err)
 	}
 
-	req, err := http.NewRequest("GET", eureka+"eureka/apps", nil)
+	req, err := http.NewRequest("GET", eureka + "eureka/apps", nil)
 	if err != nil {
 		// Should never get here
 		return "", fmt.Errorf("Unexpected error: %s", err)
@@ -73,13 +81,67 @@ func List(cliConnection plugin.CliConnection, client httpclient.Client, srInstan
 	}
 
 	tab := &format.Table{}
-	tab.Entitle([]string{"eureka app name", "zone", "status"})
+	tab.Entitle([]string{"eureka app name", "cf app name", "cf instance index", "zone", "status"})
 	for _, app := range listResp.Applications.Application {
 		instances := app.Instance
 		for _, instance := range instances {
-			tab.AddRow([]string{instance.App, instance.Metadata.Zone, instance.Status})
+			metadata := instance.Metadata
+			var cfAppNm string
+			cfInstanceIndex := metadata.CfInstanceIndex
+			if metadata.CfAppGuid == "" {
+				fmt.Printf("cf app GUID not present in metadata of eureka app %s. Perhaps the app was built with an old version of Spring Cloud Services starters.\n", instance.App)
+				cfAppNm = UnknownCfAppName
+				cfInstanceIndex = UnknownCfInstanceIndex
+			} else {
+				cfAppNm, err = cfAppName(cliConnection, metadata.CfAppGuid)
+				if err != nil {
+					return "", fmt.Errorf("Failed to determine cf app name corresponding to cf app GUID '%s': %s", metadata.CfAppGuid, err)
+				}
+			}
+			tab.AddRow([]string{instance.App, cfAppNm, cfInstanceIndex, metadata.Zone, instance.Status})
 		}
 	}
 
 	return fmt.Sprintf("Service instance: %s\nServer URL: %s\n\n%s", srInstanceName, eureka, tab.String()), nil
+}
+
+type SummaryResp struct {
+	Name string
+}
+
+type SummaryFailure struct {
+	Code        int
+	Description string
+	Error_code  string
+}
+
+func cfAppName(cliConnection plugin.CliConnection, cfAppGuid string) (string, error) {
+	output, err := cliConnection.CliCommandWithoutTerminalOutput("curl", fmt.Sprintf("/v2/apps/%s/summary", cfAppGuid), "-H", "Accept: application/json")
+	if err != nil {
+		return "", err
+	}
+
+	// Cope with some errors coming back with err == nil.
+	// See https://www.pivotaltracker.com/story/show/130060949 for a potential alternative.
+	err = diagnoseCurlError(output)
+	if err != nil {
+		return "", err
+	}
+
+	var summaryResp SummaryResp
+	err = json.Unmarshal([]byte(strings.Join(output, "\n")), &summaryResp)
+	if err != nil {
+		return "", err
+	}
+
+	return summaryResp.Name, err
+}
+
+func diagnoseCurlError(output []string) error {
+	var summaryFailure SummaryFailure
+	err := json.Unmarshal([]byte(strings.Join(output, "\n")), &summaryFailure)
+	if err == nil && summaryFailure.Code != 0 {
+		return fmt.Errorf("%s: code %d, error_code %s", summaryFailure.Description, summaryFailure.Code, summaryFailure.Error_code)
+	}
+	return nil
 }


### PR DESCRIPTION
Later versions of starters/connector enable applications to include their cf
app GUID and cf instance index in the metadata they register with eureka.

If this metadata is present, include the cf app name and cf instance index in
the table. Otherwise, issue a warning and omit those values.

[#135535861]