### PR TITLE
Implement CLI Plugin Deregister command.

### DIFF
--- a/eureka/deregister.go
+++ b/eureka/deregister.go
@@ -1,0 +1,67 @@
+package eureka
+
+import (
+	"fmt"
+
+	"errors"
+
+	"code.cloudfoundry.org/cli/plugin"
+	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient"
+)
+
+func Deregister(cliConnection plugin.CliConnection, srInstanceName string, cfAppName string, authenticatedClient httpclient.AuthenticatedClient) (string, error) {
+	return DeregisterWithResolver(cliConnection, srInstanceName, cfAppName, authenticatedClient, EurekaUrlFromDashboardUrl)
+}
+
+func DeregisterWithResolver(cliConnection plugin.CliConnection, srInstanceName string, cfAppName string, authClient httpclient.AuthenticatedClient,
+	eurekaUrlFromDashboardUrl func(dashboardUrl string, accessToken string, authClient httpclient.AuthenticatedClient) (string, error)) (string, error) {
+	serviceModel, err := cliConnection.GetService(srInstanceName)
+	if err != nil {
+		return "", fmt.Errorf("Service registry instance not found: %s", err)
+	}
+	accessToken, err := cliConnection.AccessToken()
+	if err != nil {
+		return "", fmt.Errorf("Access token not available: %s", err)
+	}
+
+	eureka, err := eurekaUrlFromDashboardUrl(serviceModel.DashboardUrl, accessToken, authClient)
+	if err != nil {
+		return "", fmt.Errorf("Error obtaining service registry dashboard URL: %s", err)
+	}
+
+	apps, err := getRegisteredAppsWithCfAppName(cliConnection, authClient, accessToken, eureka, cfAppName)
+	if err != nil {
+		return "", err
+	}
+
+	for _, app := range apps {
+		err = deregister(authClient, accessToken, eureka, app.eurekaAppName, app.instanceId)
+	}
+
+	return "", nil
+}
+
+func deregister(authClient httpclient.AuthenticatedClient, accessToken string, eureka string, eurekaAppName string, instanceId string) error {
+	return authClient.DoAuthenticatedDelete(eureka+fmt.Sprintf("eureka/apps/%s/%s", eurekaAppName, instanceId), accessToken)
+}
+
+func getRegisteredAppsWithCfAppName(cliConnection plugin.CliConnection, authClient httpclient.AuthenticatedClient, accessToken string, eureka string, cfAppName string) ([]eurekaAppRecord, error) {
+	registeredAppsWithCfAppName := []eurekaAppRecord{}
+
+	registeredApps, err := getRegisteredApps(cliConnection, authClient, accessToken, eureka, false)
+
+	if err != nil {
+		return registeredAppsWithCfAppName, err
+	}
+
+	for _, app := range registeredApps {
+		if app.cfAppName == cfAppName {
+			registeredAppsWithCfAppName = append(registeredAppsWithCfAppName, app)
+		}
+	}
+	if len(registeredAppsWithCfAppName) == 0 {
+		return registeredAppsWithCfAppName, errors.New(fmt.Sprintf("Eureka app name %s cannot be found", cfAppName))
+	}
+
+	return registeredAppsWithCfAppName, nil
+}

--- a/eureka/deregister_test.go
+++ b/eureka/deregister_test.go
@@ -1,0 +1,206 @@
+package eureka_test
+
+import (
+	//"github.com/pivotal-cf/spring-cloud-services-cli-plugin/eureka"
+
+	"bytes"
+	"errors"
+
+	"code.cloudfoundry.org/cli/plugin/models"
+	"code.cloudfoundry.org/cli/plugin/pluginfakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/eureka"
+	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient"
+	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient/httpclientfakes"
+)
+
+var _ = Describe("Deregister", func() {
+
+	var (
+		fakeCliConnection *pluginfakes.FakeCliConnection
+		fakeAuthClient    *httpclientfakes.FakeAuthenticatedClient
+		fakeResolver      func(dashboardUrl string, accessToken string, authClient httpclient.AuthenticatedClient) (string, error)
+		getServiceModel   plugin_models.GetService_Model
+		output            string
+		err               error
+	)
+
+	BeforeEach(func() {
+		fakeCliConnection = &pluginfakes.FakeCliConnection{}
+		fakeAuthClient = &httpclientfakes.FakeAuthenticatedClient{}
+		fakeAuthClient.DoAuthenticatedGetReturns(bytes.NewBufferString("https://fake.com"), nil)
+		fakeResolver = func(dashboardUrl string, accessToken string, authClient httpclient.AuthenticatedClient) (string, error) {
+			return "https://eureka-dashboard-url/", nil
+		}
+	})
+
+	JustBeforeEach(func() {
+		output, err = eureka.DeregisterWithResolver(fakeCliConnection, "some-service-registry", "some-cf-app", fakeAuthClient, fakeResolver)
+	})
+
+	Context("when the service is not found", func() {
+		BeforeEach(func() {
+			fakeCliConnection.GetServiceReturns(getServiceModel, errors.New("some error"))
+		})
+
+		It("should return a suitable error", func() {
+			Expect(fakeCliConnection.GetServiceCallCount()).To(Equal(1))
+			Expect(fakeCliConnection.GetServiceArgsForCall(0)).To(Equal("some-service-registry"))
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("Service registry instance not found: some error"))
+		})
+	})
+
+	Context("when the service is found", func() {
+		BeforeEach(func() {
+			getServiceModel.DashboardUrl = "https://spring-cloud-broker.some.host.name/x/y/z/some-guid"
+			fakeCliConnection.GetServiceReturns(getServiceModel, nil)
+		})
+
+		Context("but the access token is not available", func() {
+			var accessTokenCallCount int
+
+			BeforeEach(func() {
+				accessTokenCallCount = 0
+				fakeCliConnection.AccessTokenStub = func() (string, error) {
+					accessTokenCallCount++
+					return "", errors.New("some access token error")
+				}
+			})
+
+			It("should return a suitable error", func() {
+				Expect(accessTokenCallCount).To(Equal(1))
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("Access token not available: some access token error"))
+			})
+		})
+
+		Context("and the access token is available", func() {
+			var accessTokenCallCount int
+
+			BeforeEach(func() {
+				accessTokenCallCount = 0
+				fakeCliConnection.AccessTokenStub = func() (string, error) {
+					accessTokenCallCount++
+					return "someaccesstoken", nil
+				}
+			})
+
+			Context("but the eureka dashboard URL cannot be resolved", func() {
+				BeforeEach(func() {
+					fakeResolver = func(dashboardUrl string, accessToken string, authClient httpclient.AuthenticatedClient) (string, error) {
+						return "", errors.New("resolution error")
+					}
+				})
+
+				It("should return a suitable error", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError("Error obtaining service registry dashboard URL: resolution error"))
+				})
+			})
+
+			Context("the cf app can be resolved", func() {
+
+				BeforeEach(func() {
+					fakeResolver = func(dashboardUrl string, accessToken string, authClient httpclient.AuthenticatedClient) (string, error) {
+						return "https://spring-cloud-broker.some.host.name/x/y/z/some-guid", nil
+					}
+
+					fakeCliConnection.CliCommandWithoutTerminalOutputStub = func(args ...string) ([]string, error) {
+						return []string{`{`, `"name": "some-cf-app"`, `}`}, nil
+					}
+
+					fakeAuthClient.DoAuthenticatedGetReturns(bytes.NewBufferString(`
+						{
+						   "applications":{
+						      "application":[
+							 {
+							    "instance":[
+							       {
+								  "app":"APP-1",
+								  "status":"UP",
+								  "metadata":{
+								     "zone":"zone-a",
+								     "cfAppGuid":"062bd505-8b19-44ca-4451-4a932932143a",
+								     "cfInstanceIndex":"2"
+								  }
+							       }
+							    ]
+							 }
+						      ]
+						   }
+						}`), nil)
+
+				})
+
+				It("should successfully deregister the service", func() {
+					Expect(fakeAuthClient.DoAuthenticatedDeleteCallCount()).To(Equal(1))
+				})
+
+				Context("but only two out of three eureka instance names can be resolved", func() {
+
+					BeforeEach(func() {
+
+						fakeAuthClient.DoAuthenticatedGetReturns(bytes.NewBufferString(`
+						{
+						   "applications":{
+						      "application":[
+							 {
+							    "instance":[
+							       {
+								  "app":"APP-1",
+								  "status":"UP",
+								  "metadata":{
+								     "zone":"zone-a",
+								     "cfAppGuid":"062bd505-8b19-44ca-4451-4a932932143a",
+								     "cfInstanceIndex":"1"
+								  }
+							       },
+							       }							       {
+								  "app":"APP-2",
+								  "status":"UNKNOWN",
+								  "metadata":{
+								     "zone":"zone-a",
+								     "cfInstanceIndex":"2"
+								  }
+							       },
+							       {
+								  "app":"APP-3",
+								  "status":"UP",
+								  "metadata":{
+								     "zone":"zone-a",
+								     "cfAppGuid":"162bd505-8b19-44ca-4451-4a932932143a",
+								     "cfInstanceIndex":"3"
+								  }
+							       },
+							    ]
+							 }
+						      ]
+						   }
+						}`), nil)
+
+						It("should not deregister the service with a missing guid", func() {
+							Expect(fakeAuthClient.DoAuthenticatedDeleteCallCount()).To(Equal(2))
+						})
+					})
+				})
+
+				Context("but the eureka instance name cannot be found", func() {
+
+					BeforeEach(func() {
+
+						fakeCliConnection.CliCommandWithoutTerminalOutputStub = func(args ...string) ([]string, error) {
+							return []string{`{`, `"name": "unknown-cf-app-name"`, `}`}, nil
+						}
+					})
+
+					It("should return a suitable error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError("Eureka app name some-cf-app cannot be found"))
+					})
+				})
+			})
+		})
+	})
+})

--- a/eureka/eureka_url_resolver.go
+++ b/eureka/eureka_url_resolver.go
@@ -35,9 +35,12 @@ func EurekaUrlFromDashboardUrl(dashboardUrl string, accessToken string, authClie
 	}
 
 	err = json.Unmarshal(buffer.Bytes(), &serviceDefinitionResp)
-	if err != nil /*TODO: valid JSON with wrong content serviceDefinitionResp.Credentials.Uri != "" */ {
+	if serviceDefinitionResp.Credentials.Uri == "" {
 		return "", fmt.Errorf("Invalid service registry definition response JSON: %s, response body: '%s'", err, string(buffer.Bytes()))
-	}
 
+	}
+	if err != nil {
+		return "", fmt.Errorf("JSON reponse contained empty property 'credentials.url': %s", string(buffer.Bytes()))
+	}
 	return serviceDefinitionResp.Credentials.Uri + "/", nil
 }

--- a/eureka/list.go
+++ b/eureka/list.go
@@ -10,10 +10,16 @@ import (
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient"
 )
 
+const (
+	UnknownCfAppName       = "?????"
+	UnknownCfInstanceIndex = "?"
+)
+
 type Instance struct {
-	App      string
-	Status   string
-	Metadata struct {
+	App        string
+	InstanceId string
+	Status     string
+	Metadata   struct {
 		CfAppGuid       string
 		CfInstanceIndex string
 		Zone            string
@@ -30,10 +36,24 @@ type ListResp struct {
 	}
 }
 
-const (
-	UnknownCfAppName       = "?????"
-	UnknownCfInstanceIndex = "?"
-)
+type SummaryResp struct {
+	Name string
+}
+
+type SummaryFailure struct {
+	Code        int
+	Description string
+	Error_code  string
+}
+
+type eurekaAppRecord struct {
+	cfAppName     string
+	eurekaAppName string
+	instanceId    string
+	status        string
+	zone          string
+	instanceIndex string
+}
 
 func List(cliConnection plugin.CliConnection, srInstanceName string, authClient httpclient.AuthenticatedClient) (string, error) {
 	return ListWithResolver(cliConnection, srInstanceName, authClient, EurekaUrlFromDashboardUrl)
@@ -54,55 +74,70 @@ func ListWithResolver(cliConnection plugin.CliConnection, srInstanceName string,
 	if err != nil {
 		return "", fmt.Errorf("Error obtaining service registry dashboard URL: %s", err)
 	}
-
-	buf, err := authClient.DoAuthenticatedGet(eureka+"eureka/apps", accessToken)
-	if err != nil {
-		return "", fmt.Errorf("Service registry error: %s", err)
-	}
-
-	var listResp ListResp
-	err = json.Unmarshal(buf.Bytes(), &listResp)
-	if err != nil {
-		return "", fmt.Errorf("Invalid service registry response JSON: %s, response body: '%s'", err, string(buf.Bytes()))
-	}
-
 	tab := &format.Table{}
 	tab.Entitle([]string{"eureka app name", "cf app name", "cf instance index", "zone", "status"})
-	apps := listResp.Applications.Application
-	if len(apps) == 0 {
+	registeredApps, err := getRegisteredApps(cliConnection, authClient, accessToken, eureka, true)
+
+	if err != nil {
+		return "", err
+	}
+	if len(registeredApps) == 0 {
 		return fmt.Sprintf("Service instance: %s\nServer URL: %s\n\nNo registered applications found\n", srInstanceName, eureka), nil
 	}
-	for _, app := range apps {
-		instances := app.Instance
-		for _, instance := range instances {
-			metadata := instance.Metadata
-			var cfAppNm string
-			cfInstanceIndex := metadata.CfInstanceIndex
-			if metadata.CfAppGuid == "" {
-				fmt.Printf("cf app GUID not present in metadata of eureka app %s. Perhaps the app was built with an old version of Spring Cloud Services starters.\n", instance.App)
-				cfAppNm = UnknownCfAppName
-				cfInstanceIndex = UnknownCfInstanceIndex
-			} else {
-				cfAppNm, err = cfAppName(cliConnection, metadata.CfAppGuid)
-				if err != nil {
-					return "", fmt.Errorf("Failed to determine cf app name corresponding to cf app GUID '%s': %s", metadata.CfAppGuid, err)
-				}
-			}
-			tab.AddRow([]string{instance.App, cfAppNm, cfInstanceIndex, metadata.Zone, instance.Status})
-		}
+	for _, app := range registeredApps {
+
+		tab.AddRow([]string{app.eurekaAppName, app.cfAppName, app.instanceIndex, app.zone, app.status})
 	}
 
 	return fmt.Sprintf("Service instance: %s\nServer URL: %s\n\n%s", srInstanceName, eureka, tab.String()), nil
 }
 
-type SummaryResp struct {
-	Name string
-}
+func getRegisteredApps(cliConnection plugin.CliConnection, authClient httpclient.AuthenticatedClient, accessToken string, eureka string, asTable bool) ([]eurekaAppRecord, error) {
+	registeredApps := []eurekaAppRecord{}
+	buf, err := authClient.DoAuthenticatedGet(eureka+"eureka/apps", accessToken)
+	if err != nil {
+		return registeredApps, fmt.Errorf("Service registry error: %s", err)
+	}
 
-type SummaryFailure struct {
-	Code        int
-	Description string
-	Error_code  string
+	var listResp ListResp
+	err = json.Unmarshal(buf.Bytes(), &listResp)
+	if err != nil {
+		return registeredApps, fmt.Errorf("Invalid service registry response JSON: %s, response body: '%s'", err, string(buf.Bytes()))
+	}
+
+	apps := listResp.Applications.Application
+	for i, app := range apps {
+		instances := app.Instance
+		for _, instance := range instances {
+			metadata := instance.Metadata
+			cfInstanceIndex := metadata.CfInstanceIndex
+			var cfAppNm string
+			if metadata.CfAppGuid == "" {
+				fmt.Printf("cf app GUID not present in metadata of eureka app %s. Perhaps the app was built with an old version of Spring Cloud Services starters.\n", instance.App)
+				if asTable {
+					cfAppNm = UnknownCfAppName
+					cfInstanceIndex = UnknownCfInstanceIndex
+				} else {
+					continue
+				}
+			} else {
+				cfAppNm, err = cfAppName(cliConnection, metadata.CfAppGuid)
+				if err != nil {
+					return registeredApps, fmt.Errorf("Failed to determine cf app name corresponding to cf app GUID '%s': %s", metadata.CfAppGuid, err)
+				}
+
+			}
+			registeredApps = append(registeredApps[:i], eurekaAppRecord{
+				cfAppName:     cfAppNm,
+				eurekaAppName: instance.App,
+				instanceId:    instance.InstanceId,
+				instanceIndex: cfInstanceIndex,
+				zone:          instance.Metadata.Zone,
+				status:        instance.Status,
+			})
+		}
+	}
+	return registeredApps, nil
 }
 
 func cfAppName(cliConnection plugin.CliConnection, cfAppGuid string) (string, error) {

--- a/httpclient/httpclientfakes/fake_authenticated_client.go
+++ b/httpclient/httpclientfakes/fake_authenticated_client.go
@@ -19,6 +19,15 @@ type FakeAuthenticatedClient struct {
 		result1 *bytes.Buffer
 		result2 error
 	}
+	DoAuthenticatedDeleteStub        func(url string, accessToken string) error
+	doAuthenticatedDeleteMutex       sync.RWMutex
+	doAuthenticatedDeleteArgsForCall []struct {
+		url         string
+		accessToken string
+	}
+	doAuthenticatedDeleteReturns struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -58,11 +67,47 @@ func (fake *FakeAuthenticatedClient) DoAuthenticatedGetReturns(result1 *bytes.Bu
 	}{result1, result2}
 }
 
+func (fake *FakeAuthenticatedClient) DoAuthenticatedDelete(url string, accessToken string) error {
+	fake.doAuthenticatedDeleteMutex.Lock()
+	fake.doAuthenticatedDeleteArgsForCall = append(fake.doAuthenticatedDeleteArgsForCall, struct {
+		url         string
+		accessToken string
+	}{url, accessToken})
+	fake.recordInvocation("DoAuthenticatedDelete", []interface{}{url, accessToken})
+	fake.doAuthenticatedDeleteMutex.Unlock()
+	if fake.DoAuthenticatedDeleteStub != nil {
+		return fake.DoAuthenticatedDeleteStub(url, accessToken)
+	} else {
+		return fake.doAuthenticatedDeleteReturns.result1
+	}
+}
+
+func (fake *FakeAuthenticatedClient) DoAuthenticatedDeleteCallCount() int {
+	fake.doAuthenticatedDeleteMutex.RLock()
+	defer fake.doAuthenticatedDeleteMutex.RUnlock()
+	return len(fake.doAuthenticatedDeleteArgsForCall)
+}
+
+func (fake *FakeAuthenticatedClient) DoAuthenticatedDeleteArgsForCall(i int) (string, string) {
+	fake.doAuthenticatedDeleteMutex.RLock()
+	defer fake.doAuthenticatedDeleteMutex.RUnlock()
+	return fake.doAuthenticatedDeleteArgsForCall[i].url, fake.doAuthenticatedDeleteArgsForCall[i].accessToken
+}
+
+func (fake *FakeAuthenticatedClient) DoAuthenticatedDeleteReturns(result1 error) {
+	fake.DoAuthenticatedDeleteStub = nil
+	fake.doAuthenticatedDeleteReturns = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeAuthenticatedClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.doAuthenticatedGetMutex.RLock()
 	defer fake.doAuthenticatedGetMutex.RUnlock()
+	fake.doAuthenticatedDeleteMutex.RLock()
+	defer fake.doAuthenticatedDeleteMutex.RUnlock()
 	return fake.invocations
 }
 

--- a/plugin.go
+++ b/plugin.go
@@ -29,6 +29,13 @@ func (c *Plugin) Run(cliConnection plugin.CliConnection, args []string) {
 
 	switch args[0] {
 
+	case "service-registry-deregister":
+		serviceRegistryInstanceName := getServiceRegistryInstanceName(otherArgs, args[0])
+		cfApplicationName := getCfApplicationName(otherArgs, args[0])
+		runAction(cliConnection, fmt.Sprintf("Deleting application %s from service registry %s", format.Bold(format.Cyan(cfApplicationName)), format.Bold(format.Cyan(serviceRegistryInstanceName))), func() (string, error) {
+			return eureka.Deregister(cliConnection, serviceRegistryInstanceName, cfApplicationName, authClient)
+		})
+
 	case "service-registry-info":
 		serviceRegistryInstanceName := getServiceRegistryInstanceName(otherArgs, args[0])
 		runAction(cliConnection, fmt.Sprintf("Getting information for service registry %s", format.Bold(format.Cyan(serviceRegistryInstanceName))), func() (string, error) {
@@ -45,6 +52,13 @@ func (c *Plugin) Run(cliConnection plugin.CliConnection, args []string) {
 		os.Exit(0) // Ignore CLI-MESSAGE-UNINSTALL etc.
 
 	}
+}
+
+func getCfApplicationName(args []string, operation string) string {
+	if len(args) < 3 || args[2] == "" {
+		diagnoseWithHelp("cf application name not specified.", operation)
+	}
+	return args[2]
 }
 
 func getServiceRegistryInstanceName(args []string, operation string) string {
@@ -93,6 +107,15 @@ func (c *Plugin) GetMetadata() plugin.PluginMetadata {
 			Build: 0,
 		},
 		Commands: []plugin.Command{
+			{
+				Name:     "service-registry-deregister",
+				HelpText: "Deregister an application registered with a Spring Cloud Services service registry",
+				Alias:    "srd",
+				UsageDetails: plugin.Usage{
+					Usage:   "   cf service-registry-deregister SERVICE_REGISTRY_INSTANCE_NAME CF_APPLICATION_NAME",
+					Options: map[string]string{"--skip-ssl-validation": skipSslValidationUsage},
+				},
+			},
 			{
 				Name:     "service-registry-info",
 				HelpText: "Display Spring Cloud Services service registry instance information",


### PR DESCRIPTION
Deregister removes an instance from the Eureka service registry.
By default, Eureka is in self-preservation mode and will attempt to re-register any instance that is dregistered
Share eureka instance metadata lookup between list and deregister commands

[133143827]