### PR TITLE
Inherit --skip-ssl-validation from `cf api`

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -19,26 +19,18 @@ package cli
 import "fmt"
 import "code.cloudfoundry.org/cli/cf/flags"
 
-const (
-	SkipSslValidationUsage = "Skip verification of the service endpoint. Not recommended!"
-	CfInstanceIndexUsage   = "Operate on a specific instance in the Eureka registry. The instance index number can be found by using the service-registry-list command."
-)
+const	CfInstanceIndexUsage   = "Operate on a specific instance in the Eureka registry. The instance index number can be found by using the service-registry-list command."
 
-func ParseFlags(args []string) (bool, *int, []string, error) {
-	const (
-		sslValidationFlagName = "skip-ssl-validation"
-		instanceIndexFlagName = "cf-instance-index"
-	)
+func ParseFlags(args []string) (*int, []string, error) {
+	const	instanceIndexFlagName = "cf-instance-index"
 
 	fc := flags.New()
 	//New flag methods take arguments: name, short_name and usage of the string flag
-	fc.NewBoolFlag(sslValidationFlagName, sslValidationFlagName, SkipSslValidationUsage)
 	fc.NewIntFlag(instanceIndexFlagName, "i", CfInstanceIndexUsage)
 	err := fc.Parse(args...)
 	if err != nil {
-		return false, nil, nil, fmt.Errorf("Error parsing arguments: %s", err)
+		return nil, nil, fmt.Errorf("Error parsing arguments: %s", err)
 	}
-	skipSslValidation := fc.Bool(sslValidationFlagName)
 	//Use a pointer instead of value because 0 initialized int is a valid instance index
 	var cfInstanceIndex *int
 	if fc.IsSet(instanceIndexFlagName) {
@@ -46,5 +38,5 @@ func ParseFlags(args []string) (bool, *int, []string, error) {
 		idx = fc.Int(instanceIndexFlagName)
 		cfInstanceIndex = &idx
 	}
-	return skipSslValidation, cfInstanceIndex, fc.Args(), nil
+	return cfInstanceIndex, fc.Args(), nil
 }

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -27,13 +27,12 @@ var _ = Describe("Flags", func() {
 	var (
 		args           = []string{"cf", "srd", "provision-service-registry", "provision-sr-1", "-i", "1", "-i", "2", "-i", "3"}
 		instanceIdx    *int
-		sslNoVerify    bool
 		positionalArgs []string
 		err            error
 	)
 
 	JustBeforeEach(func() {
-		sslNoVerify, instanceIdx, positionalArgs, err = cli.ParseFlags(args)
+		instanceIdx, positionalArgs, err = cli.ParseFlags(args)
 	})
 
 	Context("when duplicate flags are passed on command line", func() {
@@ -56,31 +55,10 @@ var _ = Describe("Flags", func() {
 		})
 	})
 
-	Context("when the skip ssl validation flag is set", func() {
-
-		BeforeEach(func() {
-			args = []string{"cf", "srd", "provision-service-registry", "provision-sr-1", "--skip-ssl-validation"}
-		})
-
-		It("should capture the flags value", func() {
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sslNoVerify).To(BeTrue())
-		})
-
-		Context("when positional arguments are used by the command", func() {
-
-			It("should capture an array of positional arguments", func() {
-				Expect(err).ToNot(HaveOccurred())
-				Expect(len(positionalArgs)).To(Equal(4))
-			})
-		})
-
-	})
-
 	Context("when no flag is passed for instance index", func() {
 
 		BeforeEach(func() {
-			args = []string{"cf", "srd", "provision-service-registry", "provision-sr-1", "--skip-ssl-validation"}
+			args = []string{"cf", "srd", "provision-service-registry", "provision-sr-1"}
 		})
 
 		It("should be parsed as nil", func() {
@@ -92,7 +70,7 @@ var _ = Describe("Flags", func() {
 	Context("when a string value is passed for instance index", func() {
 
 		BeforeEach(func() {
-			args = []string{"cf", "srd", "provision-service-registry", "provision-sr-1", "--skip-ssl-validation", "-i", "one"}
+			args = []string{"cf", "srd", "provision-service-registry", "provision-sr-1", "-i", "one"}
 		})
 
 		It("should raise a suitable error", func() {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,9 +16,6 @@ USAGE:
 
 ALIAS:
    csev
-
-OPTIONS:
-   --skip-ssl-validation      Skip verification of the service endpoint. Not recommended!
 ```
 
 
@@ -33,9 +30,6 @@ USAGE:
 
 ALIAS:
    sri
-
-OPTIONS:
-   --skip-ssl-validation      Skip verification of the service endpoint. Not recommended!
 ```
 
 
@@ -50,9 +44,6 @@ USAGE:
 
 ALIAS:
    srl
-
-OPTIONS:
-   --skip-ssl-validation      Skip verification of the service endpoint. Not recommended!
 ```
 
 
@@ -69,7 +60,6 @@ ALIAS:
    sren
 
 OPTIONS:
-   --skip-ssl-validation        Skip verification of the service endpoint. Not recommended!
    --i/--cf-instance-index      Operate on a specific instance in the Eureka registry. The instance index number can be found by using the service-registry-list command.
 ```
 
@@ -87,7 +77,6 @@ ALIAS:
    srdr
 
 OPTIONS:
-   --skip-ssl-validation        Skip verification of the service endpoint. Not recommended!
    --i/--cf-instance-index      Operate on a specific instance in the Eureka registry. The instance index number can be found by using the service-registry-list command.
 ```
 
@@ -105,7 +94,6 @@ ALIAS:
    srda
 
 OPTIONS:
-   --skip-ssl-validation        Skip verification of the service endpoint. Not recommended!
    --i/--cf-instance-index      Operate on a specific instance in the Eureka registry. The instance index number can be found by using the service-registry-list command.
 ```
 

--- a/format/action.go
+++ b/format/action.go
@@ -80,7 +80,7 @@ func Diagnose(message string, writer io.Writer, onFailure func()) {
 
 	hint := ""
 	if strings.Contains(message, "unknown authority") {
-		hint = "Hint: try --skip-ssl-validation at your own risk.\n"
+		hint = "\nTIP: Use 'cf api --skip-ssl-validation' to continue with an insecure API endpoint\n"
 	}
 
 	fmt.Fprintf(writer, "%s\n%s", message, hint)

--- a/format/action_test.go
+++ b/format/action_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Actions", func() {
 		const (
 			testMessage = "some message"
 			failMessage = "FAILED"
-			certHint    = "Hint: try --skip-ssl-validation at your own risk.\n"
+			certHint    = "\nTIP: Use 'cf api --skip-ssl-validation' to continue with an insecure API endpoint\n"
 		)
 
 		var (
@@ -180,7 +180,7 @@ var _ = Describe("Actions", func() {
 
 		const (
 			failMessage = "FAILED"
-			certHint    = "Hint: try --skip-ssl-validation at your own risk.\n"
+			certHint    = "TIP: Use 'cf api --skip-ssl-validation' to continue with an insecure API endpoint\n"
 		)
 
 		var (

--- a/plugin.go
+++ b/plugin.go
@@ -40,12 +40,20 @@ var pluginVersion = "invalid version - plugin was not built correctly"
 type Plugin struct{}
 
 func (c *Plugin) Run(cliConnection plugin.CliConnection, args []string) {
-	skipSslValidation, cfInstanceIndex, positionalArgs, err := cli.ParseFlags(args)
+	cfInstanceIndex, positionalArgs, err := cli.ParseFlags(args)
 	if err != nil {
 		format.Diagnose(string(err.Error()), os.Stderr, func() {
 			os.Exit(1)
 		})
 	}
+
+	skipSslValidation, err := cliConnection.IsSSLDisabled()
+	if err != nil {
+		format.Diagnose(string(err.Error()), os.Stderr, func() {
+			os.Exit(1)
+		})
+	}
+
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipSslValidation},
 	}
@@ -96,7 +104,6 @@ func (c *Plugin) Run(cliConnection plugin.CliConnection, args []string) {
 
 	default:
 		os.Exit(0) // Ignore CLI-MESSAGE-UNINSTALL etc.
-
 	}
 }
 
@@ -112,7 +119,6 @@ func getConfigServerInstanceName(args []string, operation string) string {
 		diagnoseWithHelp("Configuration server instance name not specified.", operation)
 	}
 	return args[1]
-
 }
 
 func getPlainText(args []string, operation string) string {
@@ -171,8 +177,7 @@ func (c *Plugin) GetMetadata() plugin.PluginMetadata {
 				HelpText: "Encrypt a string using a Spring Cloud Services configuration server",
 				Alias:    "csev",
 				UsageDetails: plugin.Usage{
-					Usage:   "   cf config-server-encrypt-value CONFIG_SERVER_INSTANCE_NAME VALUE_TO_ENCRYPT",
-					Options: map[string]string{"--skip-ssl-validation": cli.SkipSslValidationUsage},
+					Usage: "   cf config-server-encrypt-value CONFIG_SERVER_INSTANCE_NAME VALUE_TO_ENCRYPT",
 				},
 			},
 			{
@@ -181,7 +186,7 @@ func (c *Plugin) GetMetadata() plugin.PluginMetadata {
 				Alias:    "srdr",
 				UsageDetails: plugin.Usage{
 					Usage:   "   cf service-registry-deregister SERVICE_REGISTRY_INSTANCE_NAME CF_APPLICATION_NAME",
-					Options: map[string]string{"--skip-ssl-validation": cli.SkipSslValidationUsage, "-i/--cf-instance-index": cli.CfInstanceIndexUsage},
+					Options: map[string]string{"-i/--cf-instance-index": cli.CfInstanceIndexUsage},
 				},
 			},
 			{
@@ -190,7 +195,7 @@ func (c *Plugin) GetMetadata() plugin.PluginMetadata {
 				Alias:    "srda",
 				UsageDetails: plugin.Usage{
 					Usage:   "   cf service-registry-disable SERVICE_REGISTRY_INSTANCE_NAME CF_APPLICATION_NAME",
-					Options: map[string]string{"--skip-ssl-validation": cli.SkipSslValidationUsage, "-i/--cf-instance-index": cli.CfInstanceIndexUsage},
+					Options: map[string]string{"-i/--cf-instance-index": cli.CfInstanceIndexUsage},
 				},
 			},
 			{
@@ -199,7 +204,7 @@ func (c *Plugin) GetMetadata() plugin.PluginMetadata {
 				Alias:    "sren",
 				UsageDetails: plugin.Usage{
 					Usage:   "   cf service-registry-enable SERVICE_REGISTRY_INSTANCE_NAME CF_APPLICATION_NAME",
-					Options: map[string]string{"--skip-ssl-validation": cli.SkipSslValidationUsage, "-i/--cf-instance-index": cli.CfInstanceIndexUsage},
+					Options: map[string]string{"-i/--cf-instance-index": cli.CfInstanceIndexUsage},
 				},
 			},
 			{
@@ -207,8 +212,7 @@ func (c *Plugin) GetMetadata() plugin.PluginMetadata {
 				HelpText: "Display Spring Cloud Services service registry instance information",
 				Alias:    "sri",
 				UsageDetails: plugin.Usage{
-					Usage:   "   cf service-registry-info SERVICE_REGISTRY_INSTANCE_NAME",
-					Options: map[string]string{"--skip-ssl-validation": cli.SkipSslValidationUsage},
+					Usage: "   cf service-registry-info SERVICE_REGISTRY_INSTANCE_NAME",
 				},
 			},
 			{
@@ -216,8 +220,7 @@ func (c *Plugin) GetMetadata() plugin.PluginMetadata {
 				HelpText: "Display all applications registered with a Spring Cloud Services service registry",
 				Alias:    "srl",
 				UsageDetails: plugin.Usage{
-					Usage:   "   cf service-registry-list SERVICE_REGISTRY_INSTANCE_NAME",
-					Options: map[string]string{"--skip-ssl-validation": cli.SkipSslValidationUsage},
+					Usage: "   cf service-registry-list SERVICE_REGISTRY_INSTANCE_NAME",
 				},
 			},
 		},


### PR DESCRIPTION
Remove the flag from all our commands and use the value which was specified on
`cf api`.

To cope with the case where a server's certificate is made invalid, still
produce a hint, but reword it to match the tip produced by `cf api` when the
certificate is invalid. Also, add a blank line before the tip so that it is
clearer when it appears.

[#138048945]