### PR TITLE
Ensure predictable colour testing

### DIFF
--- a/eureka/registry_test.go
+++ b/eureka/registry_test.go
@@ -26,6 +26,7 @@ import (
 	"code.cloudfoundry.org/cli/plugin"
 	"code.cloudfoundry.org/cli/plugin/models"
 	"code.cloudfoundry.org/cli/plugin/pluginfakes"
+	"github.com/fatih/color"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/eureka"
@@ -64,6 +65,8 @@ var _ = Describe("OperateOnApplication", func() {
 	)
 
 	BeforeEach(func() {
+		color.NoColor = false // ensure predictable colour behaviour independent of test environment
+
 		fakeCliConnection = &pluginfakes.FakeCliConnection{}
 		fakeAuthClient = &httpclientfakes.FakeAuthenticatedClient{}
 		fakeAuthClient.DoAuthenticatedGetReturns(ioutil.NopCloser(bytes.NewBufferString("https://fake.com")), 200, nil)
@@ -189,7 +192,6 @@ var _ = Describe("OperateOnApplication", func() {
 
 			It("should log progress", func() {
 				Expect(progressWriter.String()).To(Equal(fmt.Sprintf("Processing service instance %s with index %s\n", format.Bold(format.Cyan("APP-1")), format.Bold(format.Cyan("2")))))
-
 			})
 
 			Context("when the operation fails", func() {

--- a/format/action_test.go
+++ b/format/action_test.go
@@ -27,6 +27,7 @@ import (
 
 	"code.cloudfoundry.org/cli/plugin/models"
 	"code.cloudfoundry.org/cli/plugin/pluginfakes"
+	"github.com/fatih/color"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -41,7 +42,7 @@ var _ = Describe("Actions", func() {
 		)
 
 		var (
-			ok                = format.Bold(format.Green("OK"))
+			ok                string
 			fakeCliConnection *pluginfakes.FakeCliConnection
 			action            format.Action
 			onFailure         func()
@@ -49,6 +50,10 @@ var _ = Describe("Actions", func() {
 		)
 
 		BeforeEach(func() {
+			color.NoColor = false // ensure predictable colour behaviour independent of test environment
+
+			ok = format.Bold(format.Green("OK"))
+
 			fakeCliConnection = &pluginfakes.FakeCliConnection{}
 
 			fakeCliConnection.GetCurrentOrgStub = func() (plugin_models.Organization, error) {


### PR DESCRIPTION
Colouring is dependent on the terminal type, which appears to vary wildly
depending on the test environment. By forcing colouring on, colouring tests
behave consistently in the following test environments:
* ginkgo -r
* govendor test +local
* go test
* IntelliJ (run)
* IntelliJ (debug)

[#151009979]