### PR TITLE
Improve usability of command tests

### DIFF
--- a/instance/commands_test.go
+++ b/instance/commands_test.go
@@ -6,18 +6,18 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient/httpclientfakes"
 	"fmt"
+
+	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient/httpclientfakes"
 )
 
-func DescribeCommandTest(name string, command string,
+func CommandTestBody(command string,
 	commandClosure func(
 		fakeAuthClient *httpclientfakes.FakeAuthenticatedClient,
 		serviceInstanceAdminURL string,
-		accessToken string) (string, error)) bool {
+		accessToken string) (string, error)) func() {
 
-	return Describe(name, func() {
-
+	return func() {
 		const testAccessToken = "someaccesstoken"
 
 		var (
@@ -60,5 +60,5 @@ func DescribeCommandTest(name string, command string,
 				Expect(err).To(Equal(testError))
 			})
 		})
-	})
+	}
 }

--- a/instance/restage_test.go
+++ b/instance/restage_test.go
@@ -1,13 +1,14 @@
 package instance_test
 
 import (
+	. "github.com/onsi/ginkgo"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient/httpclientfakes"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/instance"
 )
 
-var _ = DescribeCommandTest("Restage", "restage",
+var _ = Describe("Restage", CommandTestBody("restage",
 	func(fakeAuthClient *httpclientfakes.FakeAuthenticatedClient, serviceInstanceAdminURL string,
 		accessToken string) (string, error) {
 
 		return instance.Restage(fakeAuthClient, serviceInstanceAdminURL, accessToken)
-	})
+	}))

--- a/instance/restart_test.go
+++ b/instance/restart_test.go
@@ -1,13 +1,14 @@
 package instance_test
 
 import (
+	. "github.com/onsi/ginkgo"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient/httpclientfakes"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/instance"
 )
 
-var _ = DescribeCommandTest("Restart", "restart",
+var _ = Describe("Restart", CommandTestBody("restart",
 	func(fakeAuthClient *httpclientfakes.FakeAuthenticatedClient, serviceInstanceAdminURL string,
 		accessToken string) (string, error) {
 
 		return instance.Restart(fakeAuthClient, serviceInstanceAdminURL, accessToken)
-	})
+	}))

--- a/instance/start_test.go
+++ b/instance/start_test.go
@@ -1,13 +1,14 @@
 package instance_test
 
 import (
+	. "github.com/onsi/ginkgo"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient/httpclientfakes"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/instance"
 )
 
-var _ = DescribeCommandTest("Start", "start",
+var _ = Describe("Start", CommandTestBody("start",
 	func(fakeAuthClient *httpclientfakes.FakeAuthenticatedClient, serviceInstanceAdminURL string,
 		accessToken string) (string, error) {
 
 		return instance.Start(fakeAuthClient, serviceInstanceAdminURL, accessToken)
-	})
+	}))

--- a/instance/stop_test.go
+++ b/instance/stop_test.go
@@ -1,13 +1,14 @@
 package instance_test
 
 import (
+	. "github.com/onsi/ginkgo"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient/httpclientfakes"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/instance"
 )
 
-var _ = DescribeCommandTest("Stop", "stop",
+var _ = Describe("Stop", CommandTestBody("stop",
 	func(fakeAuthClient *httpclientfakes.FakeAuthenticatedClient, serviceInstanceAdminURL string,
 		accessToken string) (string, error) {
 
 		return instance.Stop(fakeAuthClient, serviceInstanceAdminURL, accessToken)
-	})
+	}))


### PR DESCRIPTION
Replace DescribeCommandTest by CommandTestBody which omits the outer
`Describe`. The outer `Describe` may then be focussed, pended, etc. as usual.

[#151480636]