### PR TITLE
Incorporate error details in error when csev command fails

### DIFF
--- a/config/encrypt_test.go
+++ b/config/encrypt_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/config"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient/httpclientfakes"
+	"strings"
 )
 
 var _ = Describe("Encrypt", func() {
@@ -118,6 +119,17 @@ var _ = Describe("Encrypt", func() {
 
 		It("should propagate the error", func() {
 			Expect(err.Error()).To(ContainSubstring(errorText))
+		})
+	})
+
+	Context("when the config server's /encrypt endpoint fails but returns a body containing error details", func() {
+		var errorBody = ioutil.NopCloser(strings.NewReader("{error details}"))
+		BeforeEach(func() {
+			postResponse, postStatusCode, postErr = errorBody, 0, testError
+		})
+
+		It("should propagate an error containing error body content", func() {
+			Expect(err.Error()).To(ContainSubstring("{error details}"))
 		})
 	})
 

--- a/httpclient/authclient.go
+++ b/httpclient/authclient.go
@@ -93,7 +93,7 @@ func (c *authenticatedClient) DoAuthenticatedPost(url string, bodyType string, b
 		return nil, 0, fmt.Errorf("Authenticated post to '%s' failed: %s", url, err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, resp.StatusCode, fmt.Errorf("Authenticated post to '%s' failed: %s", url, resp.Status)
+		return resp.Body, resp.StatusCode, fmt.Errorf("Authenticated post to '%s' failed: %s", url, resp.Status)
 	}
 
 	return resp.Body, resp.StatusCode, nil

--- a/httpclient/authclient_test.go
+++ b/httpclient/authclient_test.go
@@ -268,8 +268,24 @@ var _ = Describe("Authclient", func() {
 				fakeClient.DoReturns(resp, nil)
 			})
 
-			It("should return the error", func() {
+			It("should return the error with no body content", func() {
 				Expect(err).To(MatchError("Authenticated post to 'https://eureka.pivotal.io/auth/request' failed: 404 Not found"))
+				Expect(respBody).To(BeNil())
+			})
+
+			Context("when the bad status response contains a body", func() {
+				var detailsBody  = ioutil.NopCloser(strings.NewReader("{details}"))
+
+				BeforeEach(func() {
+					resp := &http.Response{StatusCode: http.StatusNotFound, Status: "404 Not found"}
+					resp.Body = detailsBody
+					fakeClient.DoReturns(resp, nil)
+				})
+
+				It("should return the error with the body", func() {
+					Expect(err).To(MatchError("Authenticated post to 'https://eureka.pivotal.io/auth/request' failed: 404 Not found"))
+					Expect(respBody).To(Equal(detailsBody))
+				})
 			})
 		})
 	})


### PR DESCRIPTION
* If HTTP response is not OK but contains body then use that body in the error returned to the user
* this resolves #45 