### PR TITLE
Add spring-cloud-service-configuration command to CLI for SCS 3.0

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -94,6 +94,20 @@ ALIAS:
 ```
 
 
+## `cf spring-cloud-service-configuration`
+
+```
+NAME:
+   spring-cloud-service-configuration - Display configuration parameters for a Spring Cloud Services service instance
+
+USAGE:
+      cf scs-config SERVICE_INSTANCE_NAME
+
+ALIAS:
+   scs-config
+```
+
+
 ## `cf service-registry-info`
 
 ```

--- a/docs/generate-cli-docs-from-help.sh
+++ b/docs/generate-cli-docs-from-help.sh
@@ -4,7 +4,7 @@ if [ ! -z ${DEBUG} ]; then
     set -x
 fi
 
-declare -a SCS_COMMANDS=("config-server-encrypt-value" "spring-cloud-service-stop" "spring-cloud-service-start" "spring-cloud-service-restart" "spring-cloud-service-restage" "spring-cloud-service-view" "service-registry-info" "service-registry-list" "service-registry-enable" "service-registry-deregister" "service-registry-disable")
+declare -a SCS_COMMANDS=("config-server-encrypt-value" "spring-cloud-service-configuration" "spring-cloud-service-stop" "spring-cloud-service-start" "spring-cloud-service-restart" "spring-cloud-service-restage" "spring-cloud-service-view" "service-registry-info" "service-registry-list" "service-registry-enable" "service-registry-deregister" "service-registry-disable")
 CMD_DOC_FILENAME=cli.md
 
 echo "# Spring Cloud Services CF CLI Plugin Docs

--- a/instance/parameters.go
+++ b/instance/parameters.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017-Present Pivotal Software, Inc. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the under the Apache License, Version 2.0 (the "License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package instance
+
+import (
+	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient"
+	"net/http"
+	"fmt"
+	"errors"
+	"io/ioutil"
+)
+
+func Parameters(authClient httpclient.AuthenticatedClient, serviceInstanceAdminURL string, accessToken string) (string, error) {
+	bodyReader, statusCode, err := authClient.DoAuthenticatedGet(serviceInstanceAdminURL+"/parameters", accessToken)
+	if err != nil {
+		return "", err
+	}
+
+	if statusCode != http.StatusOK {
+		return "", fmt.Errorf("Service broker view instance configuration failed: %d", statusCode)
+	}
+
+	if bodyReader == nil {
+		return "", errors.New("Service broker view instance configuration response body missing")
+	}
+
+	body, err := ioutil.ReadAll(bodyReader)
+	if err != nil {
+		return "", fmt.Errorf("Cannot read service instance configuration response body: %s", err)
+	}
+
+	return string(body), nil
+}

--- a/instance/parameters_test.go
+++ b/instance/parameters_test.go
@@ -1,0 +1,101 @@
+package instance_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient/httpclientfakes"
+	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/instance"
+	"errors"
+	"net/http"
+	"io/ioutil"
+	"bytes"
+)
+
+var _ = Describe("Parameters", func() {
+
+	const (
+		testAccessToken    = "someaccesstoken"
+		parametersResponse = "parameters response"
+	)
+
+	var (
+		fakeAuthClient          *httpclientfakes.FakeAuthenticatedClient
+		serviceInstanceAdminURL string
+		output                  string
+		err                     error
+	)
+
+	BeforeEach(func() {
+		fakeAuthClient = &httpclientfakes.FakeAuthenticatedClient{}
+		serviceInstanceAdminURL = "http://servicebroker.host/cli/instances/si-guid"
+	})
+
+	JustBeforeEach(func() {
+		output, err = instance.Parameters(fakeAuthClient, serviceInstanceAdminURL, testAccessToken)
+	})
+
+	It("should issue a GET to the service broker parameters endpoint with the correct parameters", func() {
+		Expect(fakeAuthClient.DoAuthenticatedGetCallCount()).To(Equal(1))
+		url, accessToken := fakeAuthClient.DoAuthenticatedGetArgsForCall(0)
+		Expect(url).To(Equal("http://servicebroker.host/cli/instances/si-guid/parameters"))
+		Expect(accessToken).To(Equal(testAccessToken))
+	})
+
+	Context("when GET to service broker returns an error", func() {
+		var testError error
+
+		BeforeEach(func() {
+			testError = errors.New("it's all gone a bit Pete Tong")
+			fakeAuthClient.DoAuthenticatedGetReturns(nil, 0, testError)
+		})
+
+		It("should return the error", func() {
+			Expect(output).To(Equal(""))
+			Expect(err).To(Equal(testError))
+		})
+	})
+
+	Context("when GET to service broker returns a bad status code", func() {
+		BeforeEach(func() {
+			fakeAuthClient.DoAuthenticatedGetReturns(nil, http.StatusNotFound, nil)
+		})
+
+		It("should return the error", func() {
+			Expect(err).To(MatchError("Service broker view instance configuration failed: 404"))
+		})
+	})
+
+	Context("when GET to service broker returns no response reader", func() {
+		BeforeEach(func() {
+			fakeAuthClient.DoAuthenticatedGetReturns(nil, http.StatusOK, nil)
+		})
+
+		It("should return a suitable error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("Service broker view instance configuration response body missing"))
+		})
+	})
+
+	Context("when GET to service broker returns response reader that cannot be read", func() {
+		BeforeEach(func() {
+			fakeAuthClient.DoAuthenticatedGetReturns(ioutil.NopCloser(badReader{}), http.StatusOK, nil)
+		})
+
+		It("should return a suitable error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("Cannot read service instance configuration response body: read error"))
+		})
+	})
+
+	Context("when GET to service broker returns valid response", func() {
+		BeforeEach(func() {
+			fakeAuthClient.DoAuthenticatedGetReturns(ioutil.NopCloser(bytes.NewBufferString(parametersResponse)), http.StatusOK, nil)
+		})
+
+		It("should return the output from the service broker parameters endpoint", func() {
+			Expect(output).To(Equal(parametersResponse))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/plugin.go
+++ b/plugin.go
@@ -117,6 +117,12 @@ func (c *Plugin) Run(cliConnection plugin.CliConnection, args []string) {
 			return instance.RunOperation(cliConnection, authClient, serviceInstanceName, instance.View)
 		})
 
+	case "spring-cloud-service-configuration":
+		configServerInstanceName := getServiceInstanceName(argsConsumer)
+		runActionQuietly(argsConsumer, cliConnection, func() (string, error) {
+			return instance.RunOperation(cliConnection, authClient, configServerInstanceName, instance.Parameters)
+		})
+
 	case "service-registry-enable":
 		serviceRegistryInstanceName := getServiceRegistryInstanceName(argsConsumer)
 		cfApplicationName := getCfApplicationName(argsConsumer)
@@ -264,6 +270,14 @@ func (c *Plugin) GetMetadata() plugin.PluginMetadata {
 				Alias:    "scs-view",
 				UsageDetails: plugin.Usage{
 					Usage: "   cf scs-view SERVICE_INSTANCE_NAME",
+				},
+			},
+			{
+				Name:     "spring-cloud-service-configuration",
+				HelpText: "Display configuration parameters for a Spring Cloud Services service instance",
+				Alias:    "scs-config",
+				UsageDetails: plugin.Usage{
+					Usage: "   cf scs-config SERVICE_INSTANCE_NAME",
 				},
 			},
 			{


### PR DESCRIPTION
* Depends on service broker exposing /cli/instances/{svc-guid}/parameters endpoint
* This is connected to https://github.com/pivotal-cf/spring-cloud-service-broker/issues/494