### PR TITLE
URL Cleanup

### DIFF
--- a/vendor/github.com/fatih/color/README.md
+++ b/vendor/github.com/fatih/color/README.md
@@ -1,15 +1,15 @@
-# Color [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/fatih/color) [![Build Status](http://img.shields.io/travis/fatih/color.svg?style=flat-square)](https://travis-ci.org/fatih/color)
+# Color [![GoDoc](https://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://godoc.org/github.com/fatih/color) [![Build Status](https://img.shields.io/travis/fatih/color.svg?style=flat-square)](https://travis-ci.org/fatih/color)
 
 
 
 Color lets you use colorized outputs in terms of [ANSI Escape
-Codes](http://en.wikipedia.org/wiki/ANSI_escape_code#Colors) in Go (Golang). It
+Codes](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors) in Go (Golang). It
 has support for Windows too! The API can be used in several ways, pick one that
 suits you.
 
 
 
-![Color](http://i.imgur.com/c1JI0lA.png)
+![Color](https://i.imgur.com/c1JI0lA.png)
 
 
 ## Install

--- a/vendor/github.com/onsi/ginkgo/CHANGELOG.md
+++ b/vendor/github.com/onsi/ginkgo/CHANGELOG.md
@@ -3,7 +3,7 @@
 Improvements:
 
 - `Skip(message)` can be used to skip the current test.
-- Added `extensions/table` - a Ginkgo DSL for [Table Driven Tests](http://onsi.github.io/ginkgo/#table-driven-tests)
+- Added `extensions/table` - a Ginkgo DSL for [Table Driven Tests](https://onsi.github.io/ginkgo/#table-driven-tests)
 - Add `GinkgoRandomSeed()` - shorthand for `config.GinkgoConfig.RandomSeed`
 
 Bug Fixes:
@@ -45,7 +45,7 @@ Improvements:
     - `ginkgo build <path-to-package>` will now compile the package, producing a file named `package.test`
     - The compiled `package.test` file can be run directly.  This runs the tests in series.
     - To run precompiled tests in parallel, you can run: `ginkgo -p package.test`
-- Support `bootstrap`ping and `generate`ing [Agouti](http://agouti.org) specs.
+- Support `bootstrap`ping and `generate`ing [Agouti](https://agouti.org) specs.
 - `ginkgo generate` and `ginkgo bootstrap` now honor the package name already defined in a given directory
 - The `ginkgo` CLI ignores `SIGQUIT`.  Prevents its stack dump from interlacing with the underlying test suite's stack dump.
 - The `ginkgo` CLI now compiles tests into a temporary directory instead of the package directory.  This necessitates upgrading to Go v1.4+.

--- a/vendor/github.com/onsi/ginkgo/README.md
+++ b/vendor/github.com/onsi/ginkgo/README.md
@@ -1,29 +1,29 @@
-![Ginkgo: A Golang BDD Testing Framework](http://onsi.github.io/ginkgo/images/ginkgo.png)
+![Ginkgo: A Golang BDD Testing Framework](https://onsi.github.io/ginkgo/images/ginkgo.png)
 
 [![Build Status](https://travis-ci.org/onsi/ginkgo.png)](https://travis-ci.org/onsi/ginkgo)
 
-Jump to the [docs](http://onsi.github.io/ginkgo/) to learn more.  To start rolling your Ginkgo tests *now* [keep reading](#set-me-up)!
+Jump to the [docs](https://onsi.github.io/ginkgo/) to learn more.  To start rolling your Ginkgo tests *now* [keep reading](#set-me-up)!
 
 To discuss Ginkgo and get updates, join the [google group](https://groups.google.com/d/forum/ginkgo-and-gomega).
 
 ## Feature List
 
-- Ginkgo uses Go's `testing` package and can live alongside your existing `testing` tests.  It's easy to [bootstrap](http://onsi.github.io/ginkgo/#bootstrapping-a-suite) and start writing your [first tests](http://onsi.github.io/ginkgo/#adding-specs-to-a-suite)
+- Ginkgo uses Go's `testing` package and can live alongside your existing `testing` tests.  It's easy to [bootstrap](https://onsi.github.io/ginkgo/#bootstrapping-a-suite) and start writing your [first tests](https://onsi.github.io/ginkgo/#adding-specs-to-a-suite)
 
 - Structure your BDD-style tests expressively:
-    - Nestable [`Describe` and `Context` container blocks](http://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context)
-    - [`BeforeEach` and `AfterEach` blocks](http://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach) for setup and teardown
-    - [`It` blocks](http://onsi.github.io/ginkgo/#individual-specs-) that hold your assertions
-    - [`JustBeforeEach` blocks](http://onsi.github.io/ginkgo/#separating-creation-and-configuration-justbeforeeach) that separate creation from configuration (also known as the subject action pattern).
-    - [`BeforeSuite` and `AfterSuite` blocks](http://onsi.github.io/ginkgo/#global-setup-and-teardown-beforesuite-and-aftersuite) to prep for and cleanup after a suite.
+    - Nestable [`Describe` and `Context` container blocks](https://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context)
+    - [`BeforeEach` and `AfterEach` blocks](https://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach) for setup and teardown
+    - [`It` blocks](https://onsi.github.io/ginkgo/#individual-specs-) that hold your assertions
+    - [`JustBeforeEach` blocks](https://onsi.github.io/ginkgo/#separating-creation-and-configuration-justbeforeeach) that separate creation from configuration (also known as the subject action pattern).
+    - [`BeforeSuite` and `AfterSuite` blocks](https://onsi.github.io/ginkgo/#global-setup-and-teardown-beforesuite-and-aftersuite) to prep for and cleanup after a suite.
 
 - A comprehensive test runner that lets you:
-    - Mark specs as [pending](http://onsi.github.io/ginkgo/#pending-specs)
-    - [Focus](http://onsi.github.io/ginkgo/#focused-specs) individual specs, and groups of specs, either programmatically or on the command line
-    - Run your tests in [random order](http://onsi.github.io/ginkgo/#spec-permutation), and then reuse random seeds to replicate the same order.
-    - Break up your test suite into parallel processes for straightforward [test parallelization](http://onsi.github.io/ginkgo/#parallel-specs)
+    - Mark specs as [pending](https://onsi.github.io/ginkgo/#pending-specs)
+    - [Focus](https://onsi.github.io/ginkgo/#focused-specs) individual specs, and groups of specs, either programmatically or on the command line
+    - Run your tests in [random order](https://onsi.github.io/ginkgo/#spec-permutation), and then reuse random seeds to replicate the same order.
+    - Break up your test suite into parallel processes for straightforward [test parallelization](https://onsi.github.io/ginkgo/#parallel-specs)
 
-- `ginkgo`: a command line interface with plenty of handy command line arguments for [running your tests](http://onsi.github.io/ginkgo/#running-tests) and [generating](http://onsi.github.io/ginkgo/#generators) test files.  Here are a few choice examples:
+- `ginkgo`: a command line interface with plenty of handy command line arguments for [running your tests](https://onsi.github.io/ginkgo/#running-tests) and [generating](https://onsi.github.io/ginkgo/#generators) test files.  Here are a few choice examples:
     - `ginkgo -nodes=N` runs your tests in `N` parallel processes and print out coherent output in realtime
     - `ginkgo -cover` runs your tests using Golang's code coverage tool
     - `ginkgo convert` converts an XUnit-style `testing` package to a Ginkgo-style package
@@ -37,25 +37,25 @@ To discuss Ginkgo and get updates, join the [google group](https://groups.google
 
 - `ginkgo watch` [watches](https://onsi.github.io/ginkgo/#watching-for-changes) packages *and their dependencies* for changes, then reruns tests.  Run tests immediately as you develop!
 
-- Built-in support for testing [asynchronicity](http://onsi.github.io/ginkgo/#asynchronous-tests)
+- Built-in support for testing [asynchronicity](https://onsi.github.io/ginkgo/#asynchronous-tests)
 
-- Built-in support for [benchmarking](http://onsi.github.io/ginkgo/#benchmark-tests) your code.  Control the number of benchmark samples as you gather runtimes and other, arbitrary, bits of numerical information about your code. 
+- Built-in support for [benchmarking](https://onsi.github.io/ginkgo/#benchmark-tests) your code.  Control the number of benchmark samples as you gather runtimes and other, arbitrary, bits of numerical information about your code. 
 
 - [Completions for Sublime Text](https://github.com/onsi/ginkgo-sublime-completions): just use [Package Control](https://sublime.wbond.net/) to install `Ginkgo Completions`.
 
-- Straightforward support for third-party testing libraries such as [Gomock](https://code.google.com/p/gomock/) and [Testify](https://github.com/stretchr/testify).  Check out the [docs](http://onsi.github.io/ginkgo/#third-party-integrations) for details.
+- Straightforward support for third-party testing libraries such as [Gomock](https://code.google.com/p/gomock/) and [Testify](https://github.com/stretchr/testify).  Check out the [docs](https://onsi.github.io/ginkgo/#third-party-integrations) for details.
 
 - A modular architecture that lets you easily:
-    - Write [custom reporters](http://onsi.github.io/ginkgo/#writing-custom-reporters) (for example, Ginkgo comes with a [JUnit XML reporter](http://onsi.github.io/ginkgo/#generating-junit-xml-output) and a TeamCity reporter).
-    - [Adapt an existing matcher library (or write your own!)](http://onsi.github.io/ginkgo/#using-other-matcher-libraries) to work with Ginkgo
+    - Write [custom reporters](https://onsi.github.io/ginkgo/#writing-custom-reporters) (for example, Ginkgo comes with a [JUnit XML reporter](https://onsi.github.io/ginkgo/#generating-junit-xml-output) and a TeamCity reporter).
+    - [Adapt an existing matcher library (or write your own!)](https://onsi.github.io/ginkgo/#using-other-matcher-libraries) to work with Ginkgo
 
-## [Gomega](http://github.com/onsi/gomega): Ginkgo's Preferred Matcher Library
+## [Gomega](https://github.com/onsi/gomega): Ginkgo's Preferred Matcher Library
 
-Ginkgo is best paired with Gomega.  Learn more about Gomega [here](http://onsi.github.io/gomega/)
+Ginkgo is best paired with Gomega.  Learn more about Gomega [here](https://onsi.github.io/gomega/)
 
-## [Agouti](http://github.com/sclevine/agouti): A Golang Acceptance Testing Framework
+## [Agouti](https://github.com/sclevine/agouti): A Golang Acceptance Testing Framework
 
-Agouti allows you run WebDriver integration tests.  Learn more about Agouti [here](http://agouti.org)
+Agouti allows you run WebDriver integration tests.  Learn more about Agouti [here](https://agouti.org)
 
 ## Set Me Up!
 
@@ -85,16 +85,16 @@ With that said, it's great to know what your options are :)
 
 ### What Golang gives you out of the box
 
-Testing is a first class citizen in Golang, however Go's built-in testing primitives are somewhat limited: The [testing](http://golang.org/pkg/testing) package provides basic XUnit style tests and no assertion library.
+Testing is a first class citizen in Golang, however Go's built-in testing primitives are somewhat limited: The [testing](https://golang.org/pkg/testing) package provides basic XUnit style tests and no assertion library.
 
 ### Matcher libraries for Golang's XUnit style tests
 
 A number of matcher libraries have been written to augment Go's built-in XUnit style tests.  Here are two that have gained traction:
 
 - [testify](https://github.com/stretchr/testify)
-- [gocheck](http://labix.org/gocheck)
+- [gocheck](https://labix.org/gocheck)
 
-You can also use Ginkgo's matcher library [Gomega](https://github.com/onsi/gomega) in [XUnit style tests](http://onsi.github.io/gomega/#using-gomega-with-golangs-xunitstyle-tests)
+You can also use Ginkgo's matcher library [Gomega](https://github.com/onsi/gomega) in [XUnit style tests](https://onsi.github.io/gomega/#using-gomega-with-golangs-xunitstyle-tests)
 
 ### BDD style testing frameworks
 

--- a/vendor/github.com/onsi/ginkgo/config/config.go
+++ b/vendor/github.com/onsi/ginkgo/config/config.go
@@ -1,7 +1,7 @@
 /*
 Ginkgo accepts a number of configuration options.
 
-These are documented [here](http://onsi.github.io/ginkgo/#the_ginkgo_cli)
+These are documented [here](https://onsi.github.io/ginkgo/#the_ginkgo_cli)
 
 You can also learn more via
 

--- a/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go
+++ b/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go
@@ -1,11 +1,11 @@
 /*
 Ginkgo is a BDD-style testing framework for Golang
 
-The godoc documentation describes Ginkgo's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo/
+The godoc documentation describes Ginkgo's API.  More comprehensive documentation (with examples!) is available at https://onsi.github.io/ginkgo/
 
-Ginkgo's preferred matcher library is [Gomega](http://github.com/onsi/gomega)
+Ginkgo's preferred matcher library is [Gomega](https://github.com/onsi/gomega)
 
-Ginkgo on Github: http://github.com/onsi/ginkgo
+Ginkgo on Github: https://github.com/onsi/ginkgo
 
 Ginkgo is MIT-Licensed
 */
@@ -181,7 +181,7 @@ func CurrentGinkgoTestDescription() GinkgoTestDescription {
 //The optional info argument is passed to the test reporter and can be used to
 // provide the measurement data to a custom reporter with context.
 //
-//See http://onsi.github.io/ginkgo/#benchmark_tests for more details
+//See https://onsi.github.io/ginkgo/#benchmark_tests for more details
 type Benchmarker interface {
 	Time(name string, body func(), info ...interface{}) (elapsedTime time.Duration)
 	RecordValue(name string, value float64, info ...interface{})
@@ -541,7 +541,7 @@ func BeforeEach(body interface{}, timeout ...float64) bool {
 }
 
 //JustBeforeEach blocks are run before It blocks but *after* all BeforeEach blocks.  For more details,
-//read the [documentation](http://onsi.github.io/ginkgo/#separating_creation_and_configuration_)
+//read the [documentation](https://onsi.github.io/ginkgo/#separating_creation_and_configuration_)
 //
 //Like It blocks, BeforeEach blocks can be made asynchronous by providing a body function that accepts
 //a Done channel

--- a/vendor/github.com/onsi/ginkgo/internal/remote/output_interceptor_unix.go
+++ b/vendor/github.com/onsi/ginkgo/internal/remote/output_interceptor_unix.go
@@ -33,7 +33,7 @@ func (interceptor *outputInterceptor) StartInterceptingOutput() error {
 	// Call a function in ./syscall_dup_*.go
 	// If building for everything other than linux_arm64,
 	// use a "normal" syscall.Dup2(oldfd, newfd) call. If building for linux_arm64 (which doesn't have syscall.Dup2)
-	// call syscall.Dup3(oldfd, newfd, 0). They are nearly identical, see: http://linux.die.net/man/2/dup3
+	// call syscall.Dup3(oldfd, newfd, 0). They are nearly identical, see: https://linux.die.net/man/2/dup3
 	syscallDup(int(interceptor.redirectFile.Fd()), 1)
 	syscallDup(int(interceptor.redirectFile.Fd()), 2)
 

--- a/vendor/github.com/onsi/ginkgo/reporters/default_reporter.go
+++ b/vendor/github.com/onsi/ginkgo/reporters/default_reporter.go
@@ -3,7 +3,7 @@ Ginkgo's Default Reporter
 
 A number of command line flags are available to tweak Ginkgo's default output.
 
-These are documented [here](http://onsi.github.io/ginkgo/#running_tests)
+These are documented [here](https://onsi.github.io/ginkgo/#running_tests)
 */
 package reporters
 

--- a/vendor/github.com/onsi/ginkgo/reporters/junit_reporter.go
+++ b/vendor/github.com/onsi/ginkgo/reporters/junit_reporter.go
@@ -2,7 +2,7 @@
 
 JUnit XML Reporter for Ginkgo
 
-For usage instructions: http://onsi.github.io/ginkgo/#generating_junit_xml_output
+For usage instructions: https://onsi.github.io/ginkgo/#generating_junit_xml_output
 
 */
 

--- a/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty/isatty_solaris.go
+++ b/vendor/github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty/isatty_solaris.go
@@ -8,7 +8,7 @@ import (
 )
 
 // IsTerminal returns true if the given file descriptor is a terminal.
-// see: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
+// see: https://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
 func IsTerminal(fd uintptr) bool {
 	var termio unix.Termio
 	err := unix.IoctlSetTermio(int(fd), unix.TCGETA, &termio)

--- a/vendor/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
+++ b/vendor/github.com/onsi/ginkgo/reporters/teamcity_reporter.go
@@ -3,7 +3,7 @@
 TeamCity Reporter for Ginkgo
 
 Makes use of TeamCity's support for Service Messages
-http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests
+https://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests
 */
 
 package reporters

--- a/vendor/github.com/onsi/gomega/README.md
+++ b/vendor/github.com/onsi/gomega/README.md
@@ -1,14 +1,14 @@
-![Gomega: Ginkgo's Preferred Matcher Library](http://onsi.github.io/gomega/images/gomega.png)
+![Gomega: Ginkgo's Preferred Matcher Library](https://onsi.github.io/gomega/images/gomega.png)
 
 [![Build Status](https://travis-ci.org/onsi/gomega.png)](https://travis-ci.org/onsi/gomega)
 
-Jump straight to the [docs](http://onsi.github.io/gomega/) to learn about Gomega, including a list of [all available matchers](http://onsi.github.io/gomega/#provided-matchers).
+Jump straight to the [docs](https://onsi.github.io/gomega/) to learn about Gomega, including a list of [all available matchers](https://onsi.github.io/gomega/#provided-matchers).
 
 To discuss Gomega and get updates, join the [google group](https://groups.google.com/d/forum/ginkgo-and-gomega).
 
-## [Ginkgo](http://github.com/onsi/ginkgo): a BDD Testing Framework for Golang
+## [Ginkgo](https://github.com/onsi/ginkgo): a BDD Testing Framework for Golang
 
-Learn more about Ginkgo [here](http://onsi.github.io/ginkgo/)
+Learn more about Ginkgo [here](https://onsi.github.io/ginkgo/)
 
 ## Community Matchers
 

--- a/vendor/github.com/onsi/gomega/gexec/session.go
+++ b/vendor/github.com/onsi/gomega/gexec/session.go
@@ -118,7 +118,7 @@ To assert that the command has exited it is more convenient to use the Exit matc
 	Eventually(s).Should(gexec.Exit())
 
 When the process exits because it has received a particular signal, the exit code will be 128+signal-value
-(See http://www.tldp.org/LDP/abs/html/exitcodes.html and http://man7.org/linux/man-pages/man7/signal.7.html)
+(See https://www.tldp.org/LDP/abs/html/exitcodes.html and http://man7.org/linux/man-pages/man7/signal.7.html)
 
 */
 func (s *Session) ExitCode() int {

--- a/vendor/github.com/onsi/gomega/gomega_dsl.go
+++ b/vendor/github.com/onsi/gomega/gomega_dsl.go
@@ -1,13 +1,13 @@
 /*
 Gomega is the Ginkgo BDD-style testing framework's preferred matcher library.
 
-The godoc documentation describes Gomega's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/gomega/
+The godoc documentation describes Gomega's API.  More comprehensive documentation (with examples!) is available at https://onsi.github.io/gomega/
 
-Gomega on Github: http://github.com/onsi/gomega
+Gomega on Github: https://github.com/onsi/gomega
 
-Learn more about Ginkgo online: http://onsi.github.io/ginkgo
+Learn more about Ginkgo online: https://onsi.github.io/ginkgo
 
-Ginkgo on Github: http://github.com/onsi/ginkgo
+Ginkgo on Github: https://github.com/onsi/ginkgo
 
 Gomega is MIT-Licensed
 */

--- a/vendor/github.com/onsi/gomega/matchers/type_support.go
+++ b/vendor/github.com/onsi/gomega/matchers/type_support.go
@@ -4,7 +4,7 @@ Gomega matchers
 This package implements the Gomega matchers and does not typically need to be imported.
 See the docs for Gomega for documentation on the matchers
 
-http://onsi.github.io/gomega/
+https://onsi.github.io/gomega/
 */
 package matchers
 

--- a/vendor/github.com/onsi/gomega/types/types.go
+++ b/vendor/github.com/onsi/gomega/types/types.go
@@ -9,7 +9,7 @@ type GomegaTestingT interface {
 
 //All Gomega matchers must implement the GomegaMatcher interface
 //
-//For details on writing custom matchers, check out: http://onsi.github.io/gomega/#adding_your_own_matchers
+//For details on writing custom matchers, check out: https://onsi.github.io/gomega/#adding_your_own_matchers
 type GomegaMatcher interface {
 	Match(actual interface{}) (success bool, err error)
 	FailureMessage(actual interface{}) (message string)

--- a/vendor/gopkg.in/yaml.v2/README.md
+++ b/vendor/gopkg.in/yaml.v2/README.md
@@ -6,7 +6,7 @@ Introduction
 The yaml package enables Go programs to comfortably encode and decode YAML
 values. It was developed within [Canonical](https://www.canonical.com) as
 part of the [juju](https://juju.ubuntu.com) project, and is based on a
-pure Go port of the well-known [libyaml](http://pyyaml.org/wiki/LibYAML)
+pure Go port of the well-known [libyaml](https://pyyaml.org/wiki/LibYAML)
 C library to parse and generate YAML data quickly and reliably.
 
 Compatibility

--- a/vendor/gopkg.in/yaml.v2/decode_test.go
+++ b/vendor/gopkg.in/yaml.v2/decode_test.go
@@ -835,7 +835,7 @@ func (s *S) TestUnmarshalerRetry(c *C) {
 	c.Assert(su, DeepEquals, sliceUnmarshaler([]int{1}))
 }
 
-// From http://yaml.org/type/merge.html
+// From https://yaml.org/type/merge.html
 var mergeTests = `
 anchors:
   list:

--- a/vendor/gopkg.in/yaml.v2/encode.go
+++ b/vendor/gopkg.in/yaml.v2/encode.go
@@ -233,7 +233,7 @@ func isBase60Float(s string) (result bool) {
 	return base60float.MatchString(s)
 }
 
-// From http://yaml.org/type/float.html, except the regular expression there
+// From https://yaml.org/type/float.html, except the regular expression there
 // is bogus. In practice parsers do not enforce the "\.[0-9_]*" suffix.
 var base60float = regexp.MustCompile(`^[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+(?:\.[0-9_]*)?$`)
 

--- a/vendor/gopkg.in/yaml.v2/readerc.go
+++ b/vendor/gopkg.in/yaml.v2/readerc.go
@@ -149,7 +149,7 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 			switch parser.encoding {
 			case yaml_UTF8_ENCODING:
 				// Decode a UTF-8 character.  Check RFC 3629
-				// (http://www.ietf.org/rfc/rfc3629.txt) for more details.
+				// (https://www.ietf.org/rfc/rfc3629.txt) for more details.
 				//
 				// The following table (taken from the RFC) is used for
 				// decoding.
@@ -252,7 +252,7 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 
 				// The UTF-16 encoding is not as simple as one might
 				// naively think.  Check RFC 2781
-				// (http://www.ietf.org/rfc/rfc2781.txt).
+				// (https://www.ietf.org/rfc/rfc2781.txt).
 				//
 				// Normally, two subsequent bytes describe a Unicode
 				// character.  However a special technique (called a

--- a/vendor/gopkg.in/yaml.v2/scannerc.go
+++ b/vendor/gopkg.in/yaml.v2/scannerc.go
@@ -9,7 +9,7 @@ import (
 // ************
 //
 // The following notes assume that you are familiar with the YAML specification
-// (http://yaml.org/spec/cvs/current.html).  We mostly follow it, although in
+// (https://yaml.org/spec/cvs/current.html).  We mostly follow it, although in
 // some cases we are less restrictive that it requires.
 //
 // The process of transforming a YAML stream into a sequence of events is


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://man7.org/linux/man-pages/man7/signal.7.html (200) with 1 occurrences could not be migrated:  
   ([https](https://man7.org/linux/man-pages/man7/signal.7.html) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://yaml.org/spec/cvs/current.html (301) with 1 occurrences migrated to:  
  https://yaml.org/spec/cvs/current.html ([https](https://yaml.org/spec/cvs/current.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://agouti.org with 2 occurrences migrated to:  
  https://agouti.org ([https](https://agouti.org) result 200).
* [ ] http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity with 1 occurrences migrated to:  
  https://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity ([https](https://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity) result 200).
* [ ] http://en.wikipedia.org/wiki/ANSI_escape_code with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/ANSI_escape_code ([https](https://en.wikipedia.org/wiki/ANSI_escape_code) result 200).
* [ ] http://github.com/onsi/ginkgo with 3 occurrences migrated to:  
  https://github.com/onsi/ginkgo ([https](https://github.com/onsi/ginkgo) result 200).
* [ ] http://github.com/onsi/gomega with 3 occurrences migrated to:  
  https://github.com/onsi/gomega ([https](https://github.com/onsi/gomega) result 200).
* [ ] http://github.com/sclevine/agouti with 1 occurrences migrated to:  
  https://github.com/sclevine/agouti ([https](https://github.com/sclevine/agouti) result 200).
* [ ] http://godoc.org/github.com/fatih/color with 1 occurrences migrated to:  
  https://godoc.org/github.com/fatih/color ([https](https://godoc.org/github.com/fatih/color) result 200).
* [ ] http://i.imgur.com/c1JI0lA.png with 1 occurrences migrated to:  
  https://i.imgur.com/c1JI0lA.png ([https](https://i.imgur.com/c1JI0lA.png) result 200).
* [ ] http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square with 1 occurrences migrated to:  
  https://img.shields.io/badge/go-documentation-blue.svg?style=flat-square ([https](https://img.shields.io/badge/go-documentation-blue.svg?style=flat-square) result 200).
* [ ] http://img.shields.io/travis/fatih/color.svg?style=flat-square with 1 occurrences migrated to:  
  https://img.shields.io/travis/fatih/color.svg?style=flat-square ([https](https://img.shields.io/travis/fatih/color.svg?style=flat-square) result 200).
* [ ] http://labix.org/gocheck with 1 occurrences migrated to:  
  https://labix.org/gocheck ([https](https://labix.org/gocheck) result 200).
* [ ] http://linux.die.net/man/2/dup3 with 1 occurrences migrated to:  
  https://linux.die.net/man/2/dup3 ([https](https://linux.die.net/man/2/dup3) result 200).
* [ ] http://onsi.github.io/ginkgo/ with 28 occurrences migrated to:  
  https://onsi.github.io/ginkgo/ ([https](https://onsi.github.io/ginkgo/) result 200).
* [ ] http://onsi.github.io/ginkgo/images/ginkgo.png with 1 occurrences migrated to:  
  https://onsi.github.io/ginkgo/images/ginkgo.png ([https](https://onsi.github.io/ginkgo/images/ginkgo.png) result 200).
* [ ] http://onsi.github.io/gomega/ with 7 occurrences migrated to:  
  https://onsi.github.io/gomega/ ([https](https://onsi.github.io/gomega/) result 200).
* [ ] http://onsi.github.io/gomega/images/gomega.png with 1 occurrences migrated to:  
  https://onsi.github.io/gomega/images/gomega.png ([https](https://onsi.github.io/gomega/images/gomega.png) result 200).
* [ ] http://pyyaml.org/wiki/LibYAML with 1 occurrences migrated to:  
  https://pyyaml.org/wiki/LibYAML ([https](https://pyyaml.org/wiki/LibYAML) result 200).
* [ ] http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c with 1 occurrences migrated to:  
  https://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c ([https](https://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c) result 200).
* [ ] http://www.ietf.org/rfc/rfc2781.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc2781.txt ([https](https://www.ietf.org/rfc/rfc2781.txt) result 200).
* [ ] http://www.ietf.org/rfc/rfc3629.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc3629.txt ([https](https://www.ietf.org/rfc/rfc3629.txt) result 200).
* [ ] http://www.tldp.org/LDP/abs/html/exitcodes.html with 1 occurrences migrated to:  
  https://www.tldp.org/LDP/abs/html/exitcodes.html ([https](https://www.tldp.org/LDP/abs/html/exitcodes.html) result 200).
* [ ] http://yaml.org/type/float.html with 1 occurrences migrated to:  
  https://yaml.org/type/float.html ([https](https://yaml.org/type/float.html) result 200).
* [ ] http://yaml.org/type/merge.html with 1 occurrences migrated to:  
  https://yaml.org/type/merge.html ([https](https://yaml.org/type/merge.html) result 200).
* [ ] http://golang.org/pkg/testing with 1 occurrences migrated to:  
  https://golang.org/pkg/testing ([https](https://golang.org/pkg/testing) result 301).
* [ ] http://onsi.github.io/ginkgo with 1 occurrences migrated to:  
  https://onsi.github.io/ginkgo ([https](https://onsi.github.io/ginkgo) result 301).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1 with 1 occurrences
* http://127.0.0.1:7788 with 1 occurrences
* http://127.0.0.1:7788/AfterSuiteDidRun with 1 occurrences
* http://127.0.0.1:7788/BeforeSuiteDidRun with 1 occurrences
* http://127.0.0.1:7788/SpecDidComplete with 1 occurrences
* http://127.0.0.1:7788/SpecSuiteDidEnd with 1 occurrences
* http://127.0.0.1:7788/SpecSuiteWillBegin with 1 occurrences
* http://127.0.0.1:7788/SpecWillRun with 1 occurrences