### PR TITLE
Retrieving guid from service

### DIFF
--- a/instance/broker.go
+++ b/instance/broker.go
@@ -19,7 +19,6 @@ package instance
 import (
 	"fmt"
 	"net/url"
-	"strings"
 
 	"code.cloudfoundry.org/cli/plugin"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/cfutil"
@@ -52,15 +51,8 @@ func accessServiceBroker(serviceInstanceName string, cliConnection plugin.CliCon
 	if err != nil {
 		return "", "", err
 	}
-	path := parsedUrl.Path
 
-	segments := strings.Split(path, "/")
-	if len(segments) == 0 || (len(segments) == 1 && segments[0] == "") {
-		return "", "", fmt.Errorf("path of %s has no segments", serviceModel.DashboardUrl)
-	}
-	guid := segments[len(segments)-1]
-
-	parsedUrl.Path = fmt.Sprintf("/cli/instances/%s", guid)
+	parsedUrl.Path = fmt.Sprintf("/cli/instances/%s",  serviceModel.Guid)
 
 	return parsedUrl.String(), accessToken, nil
 }

--- a/instance/broker_test.go
+++ b/instance/broker_test.go
@@ -119,38 +119,11 @@ var _ = Describe("RunOperation", func() {
 			})
 		})
 
-		Context("when the dashboard URL is not in the correct format", func() {
-			Context("because it is malformed", func() {
-				BeforeEach(func() {
-					fakeCliConnection.GetServiceReturns(plugin_models.GetService_Model{
-						DashboardUrl: "://",
-					}, nil)
-				})
-
-				It("should return a suitable error", func() {
-					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError("parse ://: missing protocol scheme"))
-				})
-			})
-
-			Context("because its path format is invalid", func() {
-				BeforeEach(func() {
-					fakeCliConnection.GetServiceReturns(plugin_models.GetService_Model{
-						DashboardUrl: "https://spring-cloud-broker.some.host.name",
-					}, nil)
-				})
-
-				It("should return a suitable error", func() {
-					Expect(err).To(HaveOccurred())
-					Expect(err).To(MatchError("path of https://spring-cloud-broker.some.host.name has no segments"))
-				})
-			})
-		})
-
 		Context("when the dashboard URL is in the correct format", func() {
 			BeforeEach(func() {
 				fakeCliConnection.GetServiceReturns(plugin_models.GetService_Model{
 					DashboardUrl: "https://spring-cloud-broker.some.host.name/x/y/guid",
+					Guid: "guid",
 				}, nil)
 			})
 


### PR DESCRIPTION
Instead of using the dashboard we can get it from the service model

This allows other implementations of the dashboard that do not require the SI id