### PR TITLE
Refactor structure of operations

### DIFF
--- a/instance/operation_runner.go
+++ b/instance/operation_runner.go
@@ -19,12 +19,11 @@ package instance
 import (
 	"code.cloudfoundry.org/cli/plugin"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/cfutil"
-	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient"
 )
 
 //go:generate counterfeiter -o operationfakes/fake_operation.go . Operation
 type Operation interface {
-	Run(authClient httpclient.AuthenticatedClient, serviceInstanceAdminURL string, accessToken string) (string, error)
+	Run(serviceInstanceAdminURL string, accessToken string) (string, error)
 	IsLifecycleOperation() bool
 }
 
@@ -34,7 +33,6 @@ type OperationRunner interface {
 
 type authenticatedOperationRunner struct {
 	cliConnection              plugin.CliConnection
-	authClient                 httpclient.AuthenticatedClient
 	managementEndpointResolver ManagementEndpointResolver
 }
 
@@ -56,17 +54,15 @@ func (aor *authenticatedOperationRunner) RunOperation(
 		return "", err
 	}
 
-	return operation.Run(aor.authClient, serviceInstanceAdminURL, accessToken)
+	return operation.Run(serviceInstanceAdminURL, accessToken)
 }
 
 func NewAuthenticatedOperationRunner(
 	cliConnection plugin.CliConnection,
-	authClient httpclient.AuthenticatedClient,
 	managementEndpointResolver ManagementEndpointResolver) OperationRunner {
 
 	return &authenticatedOperationRunner{
 		cliConnection:              cliConnection,
-		authClient:                 authClient,
 		managementEndpointResolver: managementEndpointResolver,
 	}
 }

--- a/instance/operation_runner_test.go
+++ b/instance/operation_runner_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient/httpclientfakes"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/instance"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/instance/operationfakes"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/instance/resolverfakes"
@@ -35,7 +34,6 @@ var _ = Describe("OperationRunner", func() {
 		operationRunner instance.OperationRunner
 
 		fakeCliConnection *pluginfakes.FakeCliConnection
-		fakeAuthClient    *httpclientfakes.FakeAuthenticatedClient
 		fakeOperation     *operationfakes.FakeOperation
 		output            string
 
@@ -51,7 +49,6 @@ var _ = Describe("OperationRunner", func() {
 
 	BeforeEach(func() {
 		fakeCliConnection = &pluginfakes.FakeCliConnection{}
-		fakeAuthClient = &httpclientfakes.FakeAuthenticatedClient{}
 		fakeOperation = &operationfakes.FakeOperation{}
 
 		fakeOperation.IsLifecycleOperationReturns(true)
@@ -67,7 +64,7 @@ var _ = Describe("OperationRunner", func() {
 	})
 
 	JustBeforeEach(func() {
-		operationRunner = instance.NewAuthenticatedOperationRunner(fakeCliConnection, fakeAuthClient, fakeManagementEndpointResolver)
+		operationRunner = instance.NewAuthenticatedOperationRunner(fakeCliConnection, fakeManagementEndpointResolver)
 		output, err = operationRunner.RunOperation(
 			serviceInstanceName,
 			fakeOperation)
@@ -107,7 +104,7 @@ var _ = Describe("OperationRunner", func() {
 		Context("when the admin URL is retrieved correctly", func() {
 			It("invoke the operation with the correct parameters", func() {
 				Expect(fakeOperation.RunCallCount()).To(Equal(1))
-				_, serviceInstanceAdminURL, accessToken := fakeOperation.RunArgsForCall(0)
+				serviceInstanceAdminURL, accessToken := fakeOperation.RunArgsForCall(0)
 
 				Expect(serviceInstanceAdminURL).To(Equal("https://spring-cloud-broker.some.host.name/cli/instances/guid"))
 				Expect(accessToken).To(Equal(testAccessToken))

--- a/instance/operationfakes/fake_operation.go
+++ b/instance/operationfakes/fake_operation.go
@@ -4,7 +4,6 @@ package operationfakes
 import (
 	"sync"
 
-	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient"
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/instance"
 )
 
@@ -19,12 +18,11 @@ type FakeOperation struct {
 	isLifecycleOperationReturnsOnCall map[int]struct {
 		result1 bool
 	}
-	RunStub        func(httpclient.AuthenticatedClient, string, string) (string, error)
+	RunStub        func(string, string) (string, error)
 	runMutex       sync.RWMutex
 	runArgsForCall []struct {
-		arg1 httpclient.AuthenticatedClient
+		arg1 string
 		arg2 string
-		arg3 string
 	}
 	runReturns struct {
 		result1 string
@@ -90,18 +88,17 @@ func (fake *FakeOperation) IsLifecycleOperationReturnsOnCall(i int, result1 bool
 	}{result1}
 }
 
-func (fake *FakeOperation) Run(arg1 httpclient.AuthenticatedClient, arg2 string, arg3 string) (string, error) {
+func (fake *FakeOperation) Run(arg1 string, arg2 string) (string, error) {
 	fake.runMutex.Lock()
 	ret, specificReturn := fake.runReturnsOnCall[len(fake.runArgsForCall)]
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
-		arg1 httpclient.AuthenticatedClient
+		arg1 string
 		arg2 string
-		arg3 string
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("Run", []interface{}{arg1, arg2, arg3})
+	}{arg1, arg2})
+	fake.recordInvocation("Run", []interface{}{arg1, arg2})
 	fake.runMutex.Unlock()
 	if fake.RunStub != nil {
-		return fake.RunStub(arg1, arg2, arg3)
+		return fake.RunStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -116,17 +113,17 @@ func (fake *FakeOperation) RunCallCount() int {
 	return len(fake.runArgsForCall)
 }
 
-func (fake *FakeOperation) RunCalls(stub func(httpclient.AuthenticatedClient, string, string) (string, error)) {
+func (fake *FakeOperation) RunCalls(stub func(string, string) (string, error)) {
 	fake.runMutex.Lock()
 	defer fake.runMutex.Unlock()
 	fake.RunStub = stub
 }
 
-func (fake *FakeOperation) RunArgsForCall(i int) (httpclient.AuthenticatedClient, string, string) {
+func (fake *FakeOperation) RunArgsForCall(i int) (string, string) {
 	fake.runMutex.RLock()
 	defer fake.runMutex.RUnlock()
 	argsForCall := fake.runArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeOperation) RunReturns(result1 string, result2 error) {

--- a/instance/parameters.go
+++ b/instance/parameters.go
@@ -24,10 +24,12 @@ import (
 	"net/http"
 )
 
-type parametersOperation struct{}
+type parametersOperation struct{
+	authenticatedClient httpclient.AuthenticatedClient
+}
 
-func (so *parametersOperation) Run(authenticatedClient httpclient.AuthenticatedClient, serviceInstanceAdminURL string, accessToken string) (string, error) {
-	bodyReader, statusCode, err := authenticatedClient.DoAuthenticatedGet(serviceInstanceAdminURL+"/parameters", accessToken)
+func (po *parametersOperation) Run(serviceInstanceAdminURL string, accessToken string) (string, error) {
+	bodyReader, statusCode, err := po.authenticatedClient.DoAuthenticatedGet(serviceInstanceAdminURL+"/parameters", accessToken)
 	if err != nil {
 		return "", err
 	}
@@ -52,6 +54,8 @@ func (so *parametersOperation) IsLifecycleOperation() bool {
 	return false
 }
 
-func NewParametersOperation() Operation {
-	return &parametersOperation{}
+func NewParametersOperation(authenticatedClient httpclient.AuthenticatedClient) Operation {
+	return &parametersOperation{
+		authenticatedClient: authenticatedClient,
+	}
 }

--- a/instance/parameters_test.go
+++ b/instance/parameters_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Parameters", func() {
 	})
 
 	JustBeforeEach(func() {
-		output, err = instance.NewParametersOperation().Run(fakeAuthClient, serviceInstanceAdminURL, testAccessToken)
+		output, err = instance.NewParametersOperation(fakeAuthClient).Run(serviceInstanceAdminURL, testAccessToken)
 	})
 
 	It("should issue a GET to the service broker parameters endpoint with the correct parameters", func() {

--- a/instance/restage.go
+++ b/instance/restage.go
@@ -22,17 +22,21 @@ import (
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient"
 )
 
-type restageOperation struct{}
+type restageOperation struct{
+	authenticatedClient httpclient.AuthenticatedClient
+}
 
-func (so *restageOperation) Run(authenticatedClient httpclient.AuthenticatedClient, serviceInstanceAdminURL string, accessToken string) (string, error) {
-	_, err := authenticatedClient.DoAuthenticatedPut(fmt.Sprintf("%s/command?restage=", serviceInstanceAdminURL), accessToken)
+func (ro *restageOperation) Run(serviceInstanceAdminURL string, accessToken string) (string, error) {
+	_, err := ro.authenticatedClient.DoAuthenticatedPut(fmt.Sprintf("%s/command?restage=", serviceInstanceAdminURL), accessToken)
 	return "", err
 }
 
-func (so *restageOperation) IsLifecycleOperation() bool {
+func (ro *restageOperation) IsLifecycleOperation() bool {
 	return true
 }
 
-func NewRestageOperation() Operation {
-	return &restageOperation{}
+func NewRestageOperation(authenticatedClient httpclient.AuthenticatedClient) Operation {
+	return &restageOperation{
+		authenticatedClient: authenticatedClient,
+	}
 }

--- a/instance/restage_test.go
+++ b/instance/restage_test.go
@@ -10,5 +10,5 @@ var _ = Describe("Restage", CommandTestBody("restage",
 	func(fakeAuthClient *httpclientfakes.FakeAuthenticatedClient, serviceInstanceAdminURL string,
 		accessToken string) (string, error) {
 
-		return instance.NewRestageOperation().Run(fakeAuthClient, serviceInstanceAdminURL, accessToken)
+		return instance.NewRestageOperation(fakeAuthClient).Run(serviceInstanceAdminURL, accessToken)
 	}))

--- a/instance/restart.go
+++ b/instance/restart.go
@@ -22,17 +22,21 @@ import (
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient"
 )
 
-type restartOperation struct{}
+type restartOperation struct{
+	authenticatedClient httpclient.AuthenticatedClient
+}
 
-func (so *restartOperation) Run(authenticatedClient httpclient.AuthenticatedClient, serviceInstanceAdminURL string, accessToken string) (string, error) {
-	_, err := authenticatedClient.DoAuthenticatedPut(fmt.Sprintf("%s/command?restart=", serviceInstanceAdminURL), accessToken)
+func (ro *restartOperation) Run(serviceInstanceAdminURL string, accessToken string) (string, error) {
+	_, err := ro.authenticatedClient.DoAuthenticatedPut(fmt.Sprintf("%s/command?restart=", serviceInstanceAdminURL), accessToken)
 	return "", err
 }
 
-func (so *restartOperation) IsLifecycleOperation() bool {
+func (ro *restartOperation) IsLifecycleOperation() bool {
 	return true
 }
 
-func NewRestartOperation() Operation {
-	return &restartOperation{}
+func NewRestartOperation(authenticatedClient httpclient.AuthenticatedClient) Operation {
+	return &restartOperation{
+		authenticatedClient: authenticatedClient,
+	}
 }

--- a/instance/restart_test.go
+++ b/instance/restart_test.go
@@ -10,5 +10,5 @@ var _ = Describe("Restart", CommandTestBody("restart",
 	func(fakeAuthClient *httpclientfakes.FakeAuthenticatedClient, serviceInstanceAdminURL string,
 		accessToken string) (string, error) {
 
-		return instance.NewRestartOperation().Run(fakeAuthClient, serviceInstanceAdminURL, accessToken)
+		return instance.NewRestartOperation(fakeAuthClient).Run(serviceInstanceAdminURL, accessToken)
 	}))

--- a/instance/start.go
+++ b/instance/start.go
@@ -22,10 +22,12 @@ import (
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient"
 )
 
-type startOperation struct{}
+type startOperation struct{
+	authenticatedClient httpclient.AuthenticatedClient
+}
 
-func (so *startOperation) Run(authenticatedClient httpclient.AuthenticatedClient, serviceInstanceAdminURL string, accessToken string) (string, error) {
-	_, err := authenticatedClient.DoAuthenticatedPut(fmt.Sprintf("%s/command?start=", serviceInstanceAdminURL), accessToken)
+func (so *startOperation) Run(serviceInstanceAdminURL string, accessToken string) (string, error) {
+	_, err := so.authenticatedClient.DoAuthenticatedPut(fmt.Sprintf("%s/command?start=", serviceInstanceAdminURL), accessToken)
 	return "", err
 }
 
@@ -33,6 +35,8 @@ func (so *startOperation) IsLifecycleOperation() bool {
 	return true
 }
 
-func NewStartOperation() Operation {
-	return &startOperation{}
+func NewStartOperation(authenticatedClient httpclient.AuthenticatedClient) Operation {
+	return &startOperation{
+		authenticatedClient: authenticatedClient,
+	}
 }

--- a/instance/start_test.go
+++ b/instance/start_test.go
@@ -10,5 +10,5 @@ var _ = Describe("Start", CommandTestBody("start",
 	func(fakeAuthClient *httpclientfakes.FakeAuthenticatedClient, serviceInstanceAdminURL string,
 		accessToken string) (string, error) {
 
-		return instance.NewStartOperation().Run(fakeAuthClient, serviceInstanceAdminURL, accessToken)
+		return instance.NewStartOperation(fakeAuthClient).Run(serviceInstanceAdminURL, accessToken)
 	}))

--- a/instance/stop.go
+++ b/instance/stop.go
@@ -22,10 +22,12 @@ import (
 	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/httpclient"
 )
 
-type stopOperation struct{}
+type stopOperation struct{
+	authenticatedClient httpclient.AuthenticatedClient
+}
 
-func (so *stopOperation) Run(authenticatedClient httpclient.AuthenticatedClient, serviceInstanceAdminURL string, accessToken string) (string, error) {
-	_, err := authenticatedClient.DoAuthenticatedPut(fmt.Sprintf("%s/command?stop=", serviceInstanceAdminURL), accessToken)
+func (so *stopOperation) Run(serviceInstanceAdminURL string, accessToken string) (string, error) {
+	_, err := so.authenticatedClient.DoAuthenticatedPut(fmt.Sprintf("%s/command?stop=", serviceInstanceAdminURL), accessToken)
 	return "", err
 }
 
@@ -33,6 +35,8 @@ func (so *stopOperation) IsLifecycleOperation() bool {
 	return true
 }
 
-func NewStopOperation() Operation {
-	return &stopOperation{}
+func NewStopOperation(authenticatedClient httpclient.AuthenticatedClient) Operation {
+	return &stopOperation{
+		authenticatedClient: authenticatedClient,
+	}
 }

--- a/instance/stop_test.go
+++ b/instance/stop_test.go
@@ -10,5 +10,5 @@ var _ = Describe("Stop", CommandTestBody("stop",
 	func(fakeAuthClient *httpclientfakes.FakeAuthenticatedClient, serviceInstanceAdminURL string,
 		accessToken string) (string, error) {
 
-		return instance.NewStopOperation().Run(fakeAuthClient, serviceInstanceAdminURL, accessToken)
+		return instance.NewStopOperation(fakeAuthClient).Run(serviceInstanceAdminURL, accessToken)
 	}))

--- a/instance/view.go
+++ b/instance/view.go
@@ -61,10 +61,12 @@ type BackingAppInstance struct {
 	Details     string
 }
 
-type viewOperation struct{}
+type viewOperation struct{
+	authenticatedClient httpclient.AuthenticatedClient
+}
 
-func (so *viewOperation) Run(authenticatedClient httpclient.AuthenticatedClient, serviceInstanceAdminURL string, accessToken string) (string, error) {
-	bodyReader, statusCode, err := authenticatedClient.DoAuthenticatedGet(serviceInstanceAdminURL, accessToken)
+func (vo *viewOperation) Run(serviceInstanceAdminURL string, accessToken string) (string, error) {
+	bodyReader, statusCode, err := vo.authenticatedClient.DoAuthenticatedGet(serviceInstanceAdminURL, accessToken)
 	if err != nil {
 		return "", err
 	}
@@ -89,12 +91,14 @@ func (so *viewOperation) Run(authenticatedClient httpclient.AuthenticatedClient,
 	return RenderView(&viewInstanceResp)
 }
 
-func (so *viewOperation) IsLifecycleOperation() bool {
+func (vo *viewOperation) IsLifecycleOperation() bool {
 	return false
 }
 
-func NewViewOperation() Operation {
-	return &viewOperation{}
+func NewViewOperation(authenticatedClient httpclient.AuthenticatedClient) Operation {
+	return &viewOperation{
+		authenticatedClient: authenticatedClient,
+	}
 }
 
 func RenderView(viewInstanceResp *ViewInstanceResp) (string, error) {

--- a/instance/view_test.go
+++ b/instance/view_test.go
@@ -37,7 +37,7 @@ var _ = Describe("View", func() {
 	})
 
 	JustBeforeEach(func() {
-		output, err = instance.NewViewOperation().Run(fakeAuthClient, serviceInstanceAdminURL, testAccessToken)
+		output, err = instance.NewViewOperation(fakeAuthClient).Run(serviceInstanceAdminURL, testAccessToken)
 	})
 
 	It("should issue a GET with the correct parameters", func() {

--- a/plugin.go
+++ b/plugin.go
@@ -72,7 +72,7 @@ func (c *Plugin) Run(cliConnection plugin.CliConnection, args []string) {
 	authClient := httpclient.NewAuthenticatedClient(client)
 
 	managementEndpointResolver := instance.NewAuthenticatedManagementEndpointResolver(cliConnection, authClient)
-	operationRunner := instance.NewAuthenticatedOperationRunner(cliConnection, authClient, managementEndpointResolver)
+	operationRunner := instance.NewAuthenticatedOperationRunner(cliConnection, managementEndpointResolver)
 
 	argsConsumer := cli.NewArgConsumer(positionalArgs, diagnoseWithHelp)
 
@@ -93,37 +93,37 @@ func (c *Plugin) Run(cliConnection plugin.CliConnection, args []string) {
 	case "spring-cloud-service-stop":
 		serviceInstanceName := getServiceInstanceName(argsConsumer)
 		runAction(argsConsumer, cliConnection, fmt.Sprintf("Stopping service instance %s", format.Bold(format.Cyan(serviceInstanceName))), func(progressWriter io.Writer) (string, error) {
-			return operationRunner.RunOperation(serviceInstanceName, instance.NewStopOperation())
+			return operationRunner.RunOperation(serviceInstanceName, instance.NewStopOperation(authClient))
 		})
 
 	case "spring-cloud-service-start":
 		serviceInstanceName := getServiceInstanceName(argsConsumer)
 		runAction(argsConsumer, cliConnection, fmt.Sprintf("Starting service instance %s", format.Bold(format.Cyan(serviceInstanceName))), func(progressWriter io.Writer) (string, error) {
-			return operationRunner.RunOperation(serviceInstanceName, instance.NewStartOperation())
+			return operationRunner.RunOperation(serviceInstanceName, instance.NewStartOperation(authClient))
 		})
 
 	case "spring-cloud-service-restart":
 		serviceInstanceName := getServiceInstanceName(argsConsumer)
 		runAction(argsConsumer, cliConnection, fmt.Sprintf("Restarting service instance %s", format.Bold(format.Cyan(serviceInstanceName))), func(progressWriter io.Writer) (string, error) {
-			return operationRunner.RunOperation(serviceInstanceName, instance.NewRestartOperation())
+			return operationRunner.RunOperation(serviceInstanceName, instance.NewRestartOperation(authClient))
 		})
 
 	case "spring-cloud-service-restage":
 		serviceInstanceName := getServiceInstanceName(argsConsumer)
 		runAction(argsConsumer, cliConnection, fmt.Sprintf("Restaging service instance %s", format.Bold(format.Cyan(serviceInstanceName))), func(progressWriter io.Writer) (string, error) {
-			return operationRunner.RunOperation(serviceInstanceName, instance.NewRestageOperation())
+			return operationRunner.RunOperation(serviceInstanceName, instance.NewRestageOperation(authClient))
 		})
 
 	case "spring-cloud-service-view":
 		serviceInstanceName := getServiceInstanceName(argsConsumer)
 		runAction(argsConsumer, cliConnection, fmt.Sprintf("Viewing service instance %s", format.Bold(format.Cyan(serviceInstanceName))), func(progressWriter io.Writer) (string, error) {
-			return operationRunner.RunOperation(serviceInstanceName, instance.NewViewOperation())
+			return operationRunner.RunOperation(serviceInstanceName, instance.NewViewOperation(authClient))
 		})
 
 	case "spring-cloud-service-configuration":
 		configServerInstanceName := getServiceInstanceName(argsConsumer)
 		runActionQuietly(argsConsumer, cliConnection, func() (string, error) {
-			return operationRunner.RunOperation(configServerInstanceName, instance.NewParametersOperation())
+			return operationRunner.RunOperation(configServerInstanceName, instance.NewParametersOperation(authClient))
 		})
 
 	case "service-registry-enable":


### PR DESCRIPTION
- Use dependency injection instead of passing authenticatedClient per
request
- This way, operation_runner does not need that dependency