### PR TITLE
Correctly identify SCS 2 when SCS 3 also installed

### DIFF
--- a/httpclient/authclient.go
+++ b/httpclient/authclient.go
@@ -35,11 +35,11 @@ type AuthenticatedClient interface {
 }
 
 type authenticatedClient struct {
-	Httpclient Client
+	httpClient Client
 }
 
 func NewAuthenticatedClient(httpClient Client) *authenticatedClient {
-	return &authenticatedClient{Httpclient: httpClient}
+	return &authenticatedClient{httpClient: httpClient}
 }
 
 func (c *authenticatedClient) DoAuthenticatedGet(url string, accessToken string) (io.ReadCloser, int, error) {
@@ -51,7 +51,7 @@ func (c *authenticatedClient) DoAuthenticatedGet(url string, accessToken string)
 
 	req.Header.Add("Accept", "application/json")
 	addAuthorizationHeader(req, accessToken)
-	resp, err := c.Httpclient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, 0, fmt.Errorf("Authenticated get of '%s' failed: %s", url, err)
 	}
@@ -70,7 +70,7 @@ func (c *authenticatedClient) DoAuthenticatedDelete(url string, accessToken stri
 
 	req.Header.Add("Accept", "application/json")
 	addAuthorizationHeader(req, accessToken)
-	resp, err := c.Httpclient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("Authenticated delete of '%s' failed: %s", url, err)
 	}
@@ -88,7 +88,7 @@ func (c *authenticatedClient) DoAuthenticatedPost(url string, bodyType string, b
 	}
 	addAuthorizationHeader(req, accessToken)
 	req.Header.Set("Content-Type", bodyType)
-	resp, err := c.Httpclient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, 0, fmt.Errorf("Authenticated post to '%s' failed: %s", url, err)
 	}
@@ -106,7 +106,7 @@ func (c *authenticatedClient) DoAuthenticatedPut(url string, accessToken string)
 	}
 
 	addAuthorizationHeader(req, accessToken)
-	resp, err := c.Httpclient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("Authenticated put of '%s' failed: %s", url, err)
 	}


### PR DESCRIPTION
* Old logic would always pick the SCS 3 broker if installed, even when
operating on an SCS 2 service instance
* Fixed this by identifying the version based on the service offering
names, specifically the `p.` prefix. We don't have much else to go on in
 the service model that's exposed to plugins.

closes pivotal-cf/spring-cloud-services-cli-plugin#78