### PR TITLE
Fix the path to the actuator/info endpoint

### DIFF
--- a/eureka/info.go
+++ b/eureka/info.go
@@ -52,7 +52,7 @@ func Info(cliConnection plugin.CliConnection, client httpclient.Client, srInstan
 		return "", fmt.Errorf("Error obtaining service registry URL: %s", err)
 	}
 
-	req, err := http.NewRequest("GET", eureka+"info", nil)
+	req, err := http.NewRequest("GET", eureka+"actuator/info", nil)
 	if err != nil {
 		// Should never get here
 		return "", fmt.Errorf("Unexpected error: %s", err)

--- a/eureka/info_test.go
+++ b/eureka/info_test.go
@@ -19,10 +19,11 @@ package eureka_test
 import (
 	"errors"
 	"fmt"
-	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/serviceutil/serviceutilfakes"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/pivotal-cf/spring-cloud-services-cli-plugin/serviceutil/serviceutilfakes"
 
 	"code.cloudfoundry.org/cli/plugin/pluginfakes"
 	. "github.com/onsi/ginkgo"
@@ -143,7 +144,7 @@ var _ = Describe("Service Registry Info", func() {
 					It("should have sent a request to the correct URL", func() {
 						Expect(fakeClient.DoCallCount()).To(Equal(1))
 						req := fakeClient.DoArgsForCall(0)
-						Expect(req.URL.String()).To(Equal("https://eureka-dashboard-url/info"))
+						Expect(req.URL.String()).To(Equal("https://eureka-dashboard-url/actuator/info"))
 					})
 
 					It("should have sent a request with the correct accept header", func() {


### PR DESCRIPTION
The `High Availability` and `Peers` fields were not being populated when making a call to `cf service-registry-info <instance>` because the `info` endpoint location changed from Spring Boot 1.x to 2.x.